### PR TITLE
Feat/ 즉시 구매 로딩 해제 및 입찰 불가 메시지 정리

### DIFF
--- a/lib/features/item/buy_now_input/screen/buy_now_input_bottom_sheet.dart
+++ b/lib/features/item/buy_now_input/screen/buy_now_input_bottom_sheet.dart
@@ -217,8 +217,10 @@ class BuyNowInputBottomSheet extends StatelessWidget {
         isInstant: true,
       );
 
-      if (!parentContext.mounted) return;
-      Navigator.pop(parentContext);
+      // 로딩 다이얼로그는 항상 먼저 닫는다 (최상위 네비게이터 기준)
+      if (parentContext.mounted) {
+        Navigator.of(parentContext, rootNavigator: true).pop();
+      }
 
       if (!parentContext.mounted) return;
       await showDialog(
@@ -236,8 +238,9 @@ class BuyNowInputBottomSheet extends StatelessWidget {
         ),
       );
     } catch (e) {
+      // 에러가 나더라도 로딩 다이얼로그는 먼저 닫는다 (최상위 네비게이터 기준)
       if (parentContext.mounted) {
-        Navigator.pop(parentContext);
+        Navigator.of(parentContext, rootNavigator: true).pop();
 
         showDialog(
           context: parentContext,

--- a/lib/features/item/detail/screen/widgets/item_bottom_action_bar.dart
+++ b/lib/features/item/detail/screen/widgets/item_bottom_action_bar.dart
@@ -122,7 +122,9 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
     final isMyItem = widget.isMyItem;
 
     // 즉시 구매 버튼 노출 여부 (상태 + 가격 기준)
-    const disabledStatusesForBuyNow = {1001, 1002, 1007, 1009, 1011};
+    // 1001: 경매 대기, 1006: 즉시 구매 진행 중, 1007: 즉시 구매 완료,
+    // 1009: 경매 종료, 1011: 거래 정지
+    const disabledStatusesForBuyNow = {1001, 1006, 1007, 1009, 1011};
     final bool showBuyNow =
         widget.item.buyNowPrice > 0 && !disabledStatusesForBuyNow.contains(_statusCode);
 
@@ -156,6 +158,28 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
                 child: _buildBuyNowButton(),
               ),
             ],
+          ] else ...[
+            Expanded(
+              child: Container(
+                height: 40,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                decoration: BoxDecoration(
+                  color: BackgroundColor,
+                  borderRadius: BorderRadius.circular(8.7),
+                  border: Border.all(color: BorderColor),
+                ),
+                child: const Center(
+                  child: Text(
+                    '내 매물은 입찰이 불가능합니다',
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: TopBidderTextColor,
+                    ),
+                  ),
+                ),
+              ),
+            ),
           ],
         ],
       ),
@@ -186,7 +210,11 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
     final int statusCode = _statusCode ?? 0;
 
     final bool isAuctionEnded = statusCode == 1009; // 경매 종료 - 낙찰
-    final bool isAuctionActive = statusCode == 1003 || statusCode == 1006;
+    final bool isAuctionActive =
+        statusCode == 1002 ||
+        statusCode == 1003 ||
+        statusCode == 1005 ||
+        statusCode == 1008;
     final bool isBuyNowInProgress = statusCode == 1006;
     final bool isBuyNowCompleted = statusCode == 1007;
 
@@ -327,8 +355,13 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
     String reason;
     switch (statusCode) {
       case 1001: // 경매 대기
-      case 1002: // 경매 등록
         reason = '경매가 아직 시작되지 않았습니다';
+        break;
+      case 1006: // 즉시 구매 진행 중
+        reason = '즉시 구매 중인 상품입니다';
+        break;
+      case 1007: // 즉시 구매 완료
+        reason = '즉시 구매가 완료된 상품입니다';
         break;
       case 1011: // 거래 정지
         reason = '거래가 정지된 상품입니다';

--- a/lib/features/item/detail/screen/widgets/item_description_section.dart
+++ b/lib/features/item/detail/screen/widgets/item_description_section.dart
@@ -159,14 +159,26 @@ class ItemDescriptionSection extends StatelessWidget {
                     }
 
                     final bids = snapshot.data ?? [];
-                    if (bids.isEmpty) {
+
+                    // 가격이 0원인 입찰은 표시하지 않음
+                    final filteredBids = bids.where((bid) {
+                      final dynamic rawPrice = bid['price'];
+                      if (rawPrice == null) return false;
+                      if (rawPrice is num) {
+                        return rawPrice != 0;
+                      }
+                      final parsed = int.tryParse(rawPrice.toString());
+                      return parsed != null && parsed != 0;
+                    }).toList();
+
+                    if (filteredBids.isEmpty) {
                       return const Text(
                         '아직 입찰 내역이 없습니다.',
                         style: TextStyle(fontSize: 12, color: iconColor),
                       );
                     }
 
-                    final limited = bids.take(10).toList();
+                    final limited = filteredBids.take(10).toList();
 
                     return ListView.separated(
                       shrinkWrap: true,


### PR DESCRIPTION
변경 내용
1. 즉시 구매 후 서버 상태는 변경되지만 화면의 로딩 스피너가 해제되지 않는 문제를 수정했습니다.
	• 즉시 구매 바텀시트와 관련 ViewModel의 로딩 플래그를 점검했습니다.
	• 성공과 실패 흐름 모두에서 로딩이 정상적으로 해제되도록 처리했습니다.
	• 즉시 구매 완료 후 화면 상태가 즉시 반영되도록 갱신 로직을 정리했습니다.
2. 사용자가 올린 매물일 경우 하단에 입찰 불가 문구를 표시하는 기능을 추가했습니다.
3. 0원 입찰 기록은 매물 기록에서 보이지 않도록 처리했습니다.
4. 입찰 불가 시 표시되는 상태 메시지를 간결하게 정리했습니다.