### PR TITLE
Feat/ 경매 상태 코드 정비 및 입찰 내역 기준 통일

### DIFF
--- a/lib/features/item/current_trade/data/datasource/current_trade_data.dart
+++ b/lib/features/item/current_trade/data/datasource/current_trade_data.dart
@@ -74,15 +74,22 @@ class CurrentTradeDatasource {
 
       final statusRowsForItems = await _supabase
           .from('bid_status')
-          .select('item_id, text_code')
-          .eq('seller_id', user.id)
+          .select(
+              'item_id, text_code, int_code, winner_id, current_highest_bidder')
           .inFilter('item_id', itemIds);
 
       final Map<String, String> statusByItemId = {};
+      final Map<String, int> intStatusByItemId = {};
+      final Map<String, String> winnerByItemId = {};
+      final Map<String, String> highestByItemId = {};
       for (final row in statusRowsForItems) {
         final id = row['item_id']?.toString();
         if (id != null) {
           statusByItemId[id] = row['text_code']?.toString() ?? '';
+          intStatusByItemId[id] = (row['int_code'] as int?) ?? 0;
+          winnerByItemId[id] = row['winner_id']?.toString() ?? '';
+          highestByItemId[id] =
+              row['current_highest_bidder']?.toString() ?? '';
         }
       }
 
@@ -92,16 +99,65 @@ class CurrentTradeDatasource {
         final bidPrice = row['bid_price'] as int? ?? 0;
         final currentPrice = item['current_price'] as int? ?? 0;
         final rawStatus = statusByItemId[itemId] ?? '';
+        final intStatus = intStatusByItemId[itemId] ?? 0;
+        final winnerId = winnerByItemId[itemId] ?? '';
+        final highestId = highestByItemId[itemId] ?? '';
+
+        // bid_log.status 코드 (예: 1001 NORMAL_SUCCESS, 2001 LOWER_THAN_CURRENT 등)를 해석
+        final statusCode = int.tryParse(row['status']?.toString() ?? '');
+
+        String? logStatus;
+        switch (statusCode) {
+          case 1001: // NORMAL_SUCCESS
+            logStatus = '입찰 성공';
+            break;
+          case 2001: // LOWER_THAN_CURRENT
+            logStatus = '현재가보다 낮은 입찰';
+            break;
+          case 2002: // AUCTION_CLOSED
+            logStatus = '경매 종료 후 입찰';
+            break;
+          case 2003: // ITEM_LOCKED
+            logStatus = '거래정지 상품';
+            break;
+          case 3001: // PAYMENT_FAIL
+            logStatus = '결제 실패';
+            break;
+          case 3002: // PAYMENT_FAILURE_LIMIT
+            logStatus = '결제 실패 횟수 초과';
+            break;
+        }
 
         String displayStatus;
-        final bool isTopBidder = currentPrice > 0 && bidPrice == currentPrice;
-
-        if (rawStatus.contains('입찰 제한') || rawStatus.contains('거래정지')) {
-          displayStatus = '거래정지';
-        } else if (isTopBidder) {
-          displayStatus = '최고가 입찰';
+        if (logStatus != null && logStatus.isNotEmpty) {
+          // 로그 상태 코드가 정의돼 있으면 우선 사용 (결제 실패 등)
+          displayStatus = logStatus;
         } else {
-          displayStatus = '패찰';
+          // 경매 종료 여부 + winner_id / current_highest_bidder 기반으로 상태 결정
+          final bool isAuctionEnded =
+              intStatus == 1008 || intStatus == 1009 || intStatus == 1010;
+          final bool isWinner = winnerId.isNotEmpty && winnerId == user.id;
+          final bool hasHighestBid = highestId.isNotEmpty && highestId == user.id;
+
+          if (rawStatus.contains('입찰 제한') || rawStatus.contains('거래정지')) {
+            displayStatus = '거래정지';
+          } else if (isAuctionEnded) {
+            // 경매가 끝난 경우
+            if (intStatus == 1010) {
+              // 유찰 상태: 낙찰자 없이 종료
+              displayStatus = '유찰';
+            } else {
+              // 1008/1009: 낙찰 또는 패찰
+              displayStatus = isWinner ? '낙찰' : '패찰';
+            }
+          } else {
+            // 경매 진행 중인 경우: 최고가 입찰 / 상위 입찰됨
+            if (hasHighestBid) {
+              displayStatus = '최고가 입찰';
+            } else {
+              displayStatus = '상회 입찰';
+            }
+          }
         }
 
         return BidHistoryItem(
@@ -153,15 +209,55 @@ class CurrentTradeDatasource {
       return statusList.map((row) {
         final itemId = row['item_id']?.toString() ?? '';
         final item = itemsById[itemId] ?? <String, dynamic>{};
-        final status = row['text_code']?.toString() ?? '';
+        final rawStatus = row['text_code']?.toString() ?? '';
+        final intCode = row['int_code'] as int? ?? 0;
         final createdAt = row['update_at']?.toString() ?? '';
+
+        // bid_status.int_code 기준으로 한글 라벨을 매핑
+        String displayStatus;
+        switch (intCode) {
+          case 1001: // 경매 대기
+            displayStatus = '경매 대기';
+            break;
+          case 1002: // 경매 등록
+            displayStatus = '경매 등록';
+            break;
+          case 1003: // 입찰 발생
+            displayStatus = '입찰 발생';
+            break;
+          case 1005: // 상위입찰 발생
+            displayStatus = '상위 입찰 발생';
+            break;
+          case 1006: // 즉시 구매 대기
+            displayStatus = '즉시 구매 대기';
+            break;
+          case 1007: // 즉시 구매 완료
+            displayStatus = '즉시 구매 완료';
+            break;
+          case 1008: // 즉시 구매 실패
+            displayStatus = '즉시 구매 실패';
+            break;
+          case 1009: // 경매 종료 - 낙찰
+            displayStatus = '경매 종료 - 낙찰';
+            break;
+          case 1010: // 경매 종료 - 유찰
+            displayStatus = '경매 종료 - 유찰';
+            break;
+          case 1011: // 경매 정지 - 신고
+            displayStatus = '경매 정지 - 신고';
+            break;
+          default:
+            // 정의되지 않은 코드는 text_code 그대로 사용
+            displayStatus = rawStatus;
+            break;
+        }
 
         return SaleHistoryItem(
           itemId: itemId,
           title: item['title']?.toString() ?? '',
           price: (item['current_price'] as int?) ?? 0,
           thumbnailUrl: item['thumbnail_image']?.toString(),
-          status: status,
+          status: displayStatus,
           date: CurrentTradeDateFormatter.format(createdAt),
         );
       }).toList();

--- a/lib/features/item/current_trade/viewmodel/current_trade_viewmodel.dart
+++ b/lib/features/item/current_trade/viewmodel/current_trade_viewmodel.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:bidbird/core/utils/ui_set/colors.dart';
 
 import '../data/repository/current_trade_repository.dart';
 import '../model/current_trade_entity.dart';
@@ -53,23 +54,45 @@ class CurrentTradeViewModel extends ChangeNotifier {
   }
 
   static Color getStatusColor(String status) {
-    if (status.contains('최고가 입찰') ||
-        status.contains('즉시 구매') ||
+    // 경매 등록: 파란색
+    if (status.contains('경매 등록')) {
+      return blueColor;
+    }
+
+    // 경매/입찰 진행 중 또는 성공 계열: 초록색
+    if (status.contains('경매 진행 중') ||
+        status.contains('입찰 중') ||
+        status.contains('최고가 입찰') ||
+        status.contains('입찰 성공') ||
+        status.contains('즉시 구매 진행 중') ||
         status == '낙찰') {
       return Colors.green;
     }
+
+    // 상위 입찰 발생: 주황색
     if (status.contains('상위 입찰 발생')) {
       return Colors.orange;
     }
+
+    // 실패/제한 계열: 빨간색
     if (status.contains('유찰') ||
         status.contains('패찰') ||
         status.contains('입찰 제한') ||
-        status.contains('거래정지')) {
+        status.contains('거래정지') ||
+        status.contains('결제 실패') ||
+        status.contains('결제 실패 횟수 초과') ||
+        status.contains('현재가보다 낮은 입찰')) {
       return Colors.redAccent;
     }
-    if (status.contains('입찰 없음')) {
+
+    // 종료/완료 계열: 회색
+    if (status.contains('경매 종료') ||
+        status.contains('경매 종료 후 입찰') ||
+        status.contains('즉시 구매 완료') ||
+        status.contains('입찰 없음')) {
       return Colors.grey;
     }
+
     return Colors.black54;
   }
 }

--- a/lib/features/item/detail/screen/widgets/item_bottom_action_bar.dart
+++ b/lib/features/item/detail/screen/widgets/item_bottom_action_bar.dart
@@ -147,8 +147,8 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
 
     // 즉시 구매 버튼 노출 여부 (상태 + 가격 기준)
     // 1001: 경매 대기, 1006: 즉시 구매 진행 중, 1007: 즉시 구매 완료,
-    // 1009: 경매 종료, 1011: 거래 정지
-    const disabledStatusesForBuyNow = {1001, 1006, 1007, 1009, 1011};
+    // 1008/1009/1010: 경매 종료, 1011: 거래 정지
+    const disabledStatusesForBuyNow = {1001, 1006, 1007, 1008, 1009, 1010, 1011};
     final bool showBuyNow =
         widget.item.buyNowPrice > 0 && !disabledStatusesForBuyNow.contains(_statusCode);
 
@@ -259,12 +259,12 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
     final bool isTopBidder = _isTopBidder;
     final int statusCode = _statusCode ?? 0;
 
-    final bool isAuctionEnded = statusCode == 1009; // 경매 종료 - 낙찰
+    final bool isAuctionEnded =
+        statusCode == 1008 || statusCode == 1009 || statusCode == 1010; // 경매 종료
     final bool isAuctionActive =
         statusCode == 1002 ||
         statusCode == 1003 ||
-        statusCode == 1005 ||
-        statusCode == 1008;
+        statusCode == 1005;
     final bool isBuyNowInProgress = statusCode == 1006;
     final bool isBuyNowCompleted = statusCode == 1007;
 
@@ -383,22 +383,37 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
 
     // 입찰이 비활성화된 경우: 이유를 버튼 형태로 표시
     String reason;
-    switch (statusCode) {
-      case 1001: // 경매 대기
-        reason = '경매가 아직 시작되지 않았습니다';
-        break;
-      case 1006: // 즉시 구매 진행 중
-        reason = '즉시 구매 중인 상품입니다';
-        break;
-      case 1007: // 즉시 구매 완료
-        reason = '즉시 구매가 완료된 상품입니다';
-        break;
-      case 1011: // 거래 정지
-        reason = '거래가 정지된 상품입니다';
-        break;
-      default:
-        reason = '현재 입찰할 수 없습니다';
-        break;
+
+    // 1) 이미 최고 입찰자인 경우
+    if (isTopBidder) {
+      reason = '이미 이 상품의 최고 입찰자입니다';
+    } else {
+      // 2) 상태 코드별 상세 사유
+      switch (statusCode) {
+        case 1001: // 경매 대기
+          reason = '경매가 아직 시작되지 않았습니다';
+          break;
+        case 1008: // 경매 종료 - 즉시 구매 실패
+        case 1009: // 경매 종료 - 낙찰
+        case 1010: // 경매 종료 - 유찰
+          reason = '경매가 종료되었습니다.';
+          break;
+        case 1006: // 즉시 구매 진행 중
+          reason = '즉시 구매 중인 상품입니다';
+          break;
+        case 1007: // 즉시 구매 완료
+          reason = '즉시 구매가 완료된 상품입니다';
+          break;
+        case 1011: // 거래 정지
+          reason = '거래가 정지된 상품입니다';
+          break;
+        case 0: // 상태 코드 로딩 실패 등
+          reason = '상품 상태 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요';
+          break;
+        default:
+          reason = '현재 입찰할 수 없습니다';
+          break;
+      }
     }
 
     return Container(

--- a/lib/features/item/user_profile/screen/user_profile_screen.dart
+++ b/lib/features/item/user_profile/screen/user_profile_screen.dart
@@ -196,6 +196,7 @@ class _UserReviewSection extends StatelessWidget {
         ),
         const SizedBox(height: 12),
         Container(
+          width: double.infinity,
           padding: const EdgeInsets.all(16),
           decoration: BoxDecoration(
             color: BorderColor.withValues(alpha: 0.3),


### PR DESCRIPTION
1. 상태 코드 1010을 경매 종료(유찰)로 처리했습니다.
	• 1010일 때 입찰 및 즉시 구매 버튼 비활성화
	• “경매가 종료되었습니다.” 메시지 출력
	• 기존 상태 코드 분기 구조에 1010을 추가했습니다.
2. 상대 유저 프로필 표시 로직을 수정했습니다.
3. 현재 거래 내역의 상태 코드 값을 실제 정의에 맞게 수정했습니다.
4. 입찰 내역 리스트의 상태 표시 기준을 다음과 같이 정리했습니다.
	• 낙찰: 경매 종료 상태이며 winner_id가 나일 때
	• 패찰: 경매 종료 상태이며 winner_id가 내가 아닐 때
	• 최고가 입찰: 경매 진행 중이며 bid_user가 나일 때
	• 상회 입찰됨: 경매 진행 중이며 bid_user가 내가 아닐 때
5. 입찰 내역 판단 기준을 “입찰한 사람(나)” 중심으로 재정비했습니다.
	• 기존의 seller 기준 필터를 제거했습니다.
	• 모든 seller의 bid_status에서 int_code, winner_id, current_highest_bidder를 직접 읽도록 수정했습니다.