### PR TITLE
Feat/ 거래·입찰 상태 정정 및 상세 화면 집계 로직 수정

### DIFF
--- a/lib/features/item/current_trade/data/datasource/current_trade_data.dart
+++ b/lib/features/item/current_trade/data/datasource/current_trade_data.dart
@@ -142,13 +142,12 @@ class CurrentTradeDatasource {
           if (rawStatus.contains('입찰 제한') || rawStatus.contains('거래정지')) {
             displayStatus = '거래정지';
           } else if (isAuctionEnded) {
-            // 경매가 끝난 경우
-            if (intStatus == 1010) {
-              // 유찰 상태: 낙찰자 없이 종료
-              displayStatus = '유찰';
+            // 경매가 끝난 경우 (구매자 관점에서는 낙찰 또는 패찰만 구분)
+            if (isWinner) {
+              displayStatus = '낙찰';
             } else {
-              // 1008/1009: 낙찰 또는 패찰
-              displayStatus = isWinner ? '낙찰' : '패찰';
+              // 유찰(1010) 포함, 내가 낙찰자가 아니면 모두 패찰로 표기
+              displayStatus = '패찰';
             }
           } else {
             // 경매 진행 중인 경우: 최고가 입찰 / 상위 입찰됨

--- a/lib/features/item/detail/data/datasource/item_detail_datasource.dart
+++ b/lib/features/item/detail/data/datasource/item_detail_datasource.dart
@@ -123,6 +123,8 @@ class ItemDetailDatasource {
           .from('bid_log')
           .select('id')
           .eq('item_id', itemId)
+          // 즉시 입찰(is_instant=true)은 참여 입찰 수에서 제외
+          .or('is_instant.is.null,is_instant.eq.false')
           .count(CountOption.exact);
       return countResponse.count;
     } catch (e) {
@@ -229,6 +231,8 @@ class ItemDetailDatasource {
           .from('bid_log')
           .select('bid_price, created_at')
           .eq('item_id', itemId)
+          // 즉시 입찰 로그는 상세 화면 히스토리에서 제외
+          .or('is_instant.is.null,is_instant.eq.false')
           .order('created_at', ascending: false)
           .limit(10);
 


### PR DESCRIPTION
1. 현재 거래내역의 입찰내역에서 기존 유찰 표기를 패찰로 통일했습니다.
2. 상세보기 화면에서 참여 입찰 건수를 계산할 때 즉시 거래 건수를 제외하도록 집계 방식을 수정했습니다.