### PR TITLE
Feat/ item_add 구조 정비 및 입력·검증·내비게이션 개선

### DIFF
--- a/lib/features/item/add/screen/item_add_screen.dart
+++ b/lib/features/item/add/screen/item_add_screen.dart
@@ -1,11 +1,15 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:bidbird/core/utils/ui_set/colors.dart';
 import 'package:bidbird/core/utils/ui_set/border_radius.dart';
 import 'package:bidbird/core/widgets/components/pop_up/ask_popup.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
 import '../viewmodel/item_add_viewmodel.dart';
+import '../widget/item_add_image_section.dart';
+import '../widget/item_add_price_section.dart';
+import '../widget/labeled_dropdown.dart';
+import '../widget/labeled_text_field.dart';
 
 class ItemAddScreen extends StatelessWidget {
   const ItemAddScreen({super.key});
@@ -32,20 +36,6 @@ class ItemAddScreen extends StatelessWidget {
       ),
       filled: true,
       fillColor: Colors.white,
-    );
-  }
-
-  Widget _buildLabel(String text) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8.0),
-      child: Text(
-        text,
-        style: const TextStyle(
-          fontSize: 14,
-          fontWeight: FontWeight.w600,
-          color: textColor,
-        ),
-      ),
     );
   }
 
@@ -87,7 +77,14 @@ class ItemAddScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final ItemAddViewModel viewModel = context.watch<ItemAddViewModel>();
 
-    return Scaffold(
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (didPop) {
+        if (!didPop) {
+          context.go('/home');
+        }
+      },
+      child: Scaffold(
       appBar: AppBar(
         title: const Text('매물 등록'),
         centerTitle: true,
@@ -98,173 +95,40 @@ class ItemAddScreen extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              _buildLabel('상품 이미지'),
-              Container(
-                height: 160,
-                width: double.infinity,
-                decoration: BoxDecoration(
-                  color: BackgroundColor,
-                  borderRadius: defaultBorder,
-                  border: Border.all(color: BackgroundColor),
+              const Padding(
+                padding: EdgeInsets.only(bottom: 8.0),
+                child: Text(
+                  '상품 이미지',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: textColor,
+                  ),
                 ),
-                child: Stack(
-                  children: [
-                    if (viewModel.selectedImages.isEmpty)
-                      Center(
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(
-                              Icons.file_upload_outlined,
-                              color: iconColor,
-                              size: 32,
-                            ),
-                            const SizedBox(height: 8),
-                            const Text(
-                              '이미지를 업로드하세요',
-                              style: TextStyle(
-                                fontSize: 13,
-                                color: iconColor,
-                              ),
-                            ),
-                          ],
-                        ),
-                      )
-                    else
-                      ListView.separated(
-                        scrollDirection: Axis.horizontal,
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 12,
-                          vertical: 12,
-                        ),
-                        itemBuilder: (context, index) {
-                          final image = viewModel.selectedImages[index];
-                          final bool isPrimary =
-                              index == viewModel.primaryImageIndex;
-                          return GestureDetector(
-                            onTap: () {
-                              viewModel.setPrimaryImage(index);
-                            },
-                            child: Stack(
-                              children: [
-                                ClipRRect(
-                                  borderRadius: defaultBorder,
-                                  child: Image.file(
-                                    File(image.path),
-                                    width: 120,
-                                    height: 120,
-                                    fit: BoxFit.cover,
-                                  ),
-                                ),
-                                Positioned(
-                                  top: 4,
-                                  right: 4,
-                                  child: GestureDetector(
-                                    onTap: () {
-                                      viewModel.removeImageAt(index);
-                                    },
-                                    child: Container(
-                                      width: 20,
-                                      height: 20,
-                                      decoration: BoxDecoration(
-                                        color: Colors.black54,
-                                        borderRadius:
-                                            BorderRadius.circular(10),
-                                      ),
-                                      alignment: Alignment.center,
-                                      child: const Icon(
-                                        Icons.close,
-                                        size: 14,
-                                        color: Colors.white,
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                                if (isPrimary)
-                                  Positioned.fill(
-                                    child: Center(
-                                      child: Container(
-                                        padding: const EdgeInsets.symmetric(
-                                          horizontal: 8,
-                                          vertical: 4,
-                                        ),
-                                        decoration: BoxDecoration(
-                                          color: blueColor,
-                                          borderRadius: BorderRadius.circular(6),
-                                        ),
-                                        child: const Text(
-                                          '대표 이미지',
-                                          style: TextStyle(
-                                            color: Colors.white,
-                                            fontSize: 11,
-                                            fontWeight: FontWeight.w600,
-                                          ),
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                              ],
-                            ),
-                          );
-                        },
-                        separatorBuilder: (_, __) => const SizedBox(width: 8),
-                        itemCount: viewModel.selectedImages.length,
-                      ),
-                    Positioned(
-                      right: 8,
-                      bottom: 8,
-                      child: GestureDetector(
-                        onTap: () => _showImageSourceSheet(context, viewModel),
-                        child: Container(
-                          width: 32,
-                          height: 32,
-                          decoration: BoxDecoration(
-                            color: blueColor,
-                            borderRadius: BorderRadius.circular(defaultRadius),
-                          ),
-                          child: const Icon(
-                            Icons.add,
-                            color: Colors.white,
-                            size: 20,
-                          ),
-                        ),
-                      ),
-                    ),
-                    Positioned(
-                      left: 8,
-                      bottom: 8,
-                      child: Container(
-                        width: 32,
-                        height: 32,
-                        decoration: BoxDecoration(
-                          color: blueColor,
-                          borderRadius: BorderRadius.circular(defaultRadius),
-                        ),
-                        alignment: Alignment.center,
-                        child: FittedBox(
-                          fit: BoxFit.scaleDown,
-                          child: Text(
-                            '${viewModel.selectedImages.length}/10',
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 12,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
+              ),
+              ItemAddImagesSection(
+                viewModel: viewModel,
+                onTapAdd: () => _showImageSourceSheet(context, viewModel),
               ),
               const SizedBox(height: 24),
-              _buildLabel('제목'),
-              TextField(
+              LabeledTextField(
+                label: '제목',
                 controller: viewModel.titleController,
                 decoration: _inputDecoration('상품 제목을 입력하세요')
-                  .copyWith(fillColor: Colors.white),
+                    .copyWith(fillColor: Colors.white),
               ),
               const SizedBox(height: 20),
-              _buildLabel('카테고리'),
+              const Padding(
+                padding: EdgeInsets.only(bottom: 8.0),
+                child: Text(
+                  '카테고리',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: textColor,
+                  ),
+                ),
+              ),
               viewModel.isLoadingKeywords
                   ? Container(
                       height: 48,
@@ -281,8 +145,9 @@ class ItemAddScreen extends StatelessWidget {
                         child: CircularProgressIndicator(strokeWidth: 2),
                       ),
                     )
-                  : DropdownButtonFormField<int>(
-                      initialValue: viewModel.selectedKeywordTypeId,
+                  : LabeledDropdown<int>(
+                      label: '',
+                      value: viewModel.selectedKeywordTypeId,
                       items: viewModel.keywordTypes
                           .map(
                             (e) => DropdownMenuItem<int>(
@@ -301,111 +166,16 @@ class ItemAddScreen extends StatelessWidget {
                         viewModel.setSelectedKeywordTypeId(value);
                       },
                       decoration: _inputDecoration('카테고리 선택'),
-                      icon: const Icon(Icons.keyboard_arrow_down_rounded),
-                      dropdownColor: Colors.white,
-                      style: const TextStyle(
-                        fontSize: 13,
-                        color: Colors.black87,
-                      ),
                     ),
               const SizedBox(height: 20),
-              Row(
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        _buildLabel('시작가 (원)'),
-                        TextField(
-                          controller: viewModel.startPriceController,
-                          keyboardType: TextInputType.number,
-                          decoration: _inputDecoration('시작 가격 입력'),
-                          onChanged: (value) {
-                            final formatted = viewModel.formatNumber(value);
-                            if (formatted != value) {
-                              viewModel.startPriceController.value =
-                                  TextEditingValue(
-                                text: formatted,
-                                selection: TextSelection.collapsed(
-                                    offset: formatted.length),
-                              );
-                            }
-                          },
-                        ),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.only(bottom: 4.0),
-                          child: Row(
-                            children: [
-                              const Expanded(
-                                child: Text(
-                                  '즉시 입찰가 (원)',
-                                  style: TextStyle(
-                                    fontSize: 14,
-                                    fontWeight: FontWeight.w600,
-                                    color: textColor,
-                                  ),
-                                ),
-                              ),
-                              Checkbox(
-                                value: viewModel.useInstantPrice,
-                                activeColor: blueColor,
-                                checkColor: Colors.white,
-                                side: BorderSide(
-                                  color: viewModel.useInstantPrice
-                                      ? blueColor
-                                      : Colors.black,
-                                ),
-                                visualDensity:
-                                    const VisualDensity(horizontal: -4, vertical: -4),
-                                materialTapTargetSize:
-                                    MaterialTapTargetSize.shrinkWrap,
-                                onChanged: (value) {
-                                  if (value == null) return;
-                                  viewModel.setUseInstantPrice(value);
-                                },
-                              ),
-                            ],
-                          ),
-                        ),
-                        TextField(
-                          controller: viewModel.instantPriceController,
-                          keyboardType: TextInputType.number,
-                          enabled: viewModel.useInstantPrice,
-                          decoration:
-                              _inputDecoration('즉시 입찰가 입력').copyWith(
-                            fillColor: viewModel.useInstantPrice
-                                ? Colors.white
-                                : BorderColor.withValues(alpha: 0.2),
-                          ),
-                          onChanged: (value) {
-                            final formatted = viewModel.formatNumber(value);
-                            if (formatted != value) {
-                              viewModel.instantPriceController.value =
-                                  TextEditingValue(
-                                text: formatted,
-                                selection: TextSelection.collapsed(
-                                    offset: formatted.length),
-                              );
-                            }
-                          },
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
+              ItemAddPriceSection(
+                viewModel: viewModel,
+                inputDecoration: _inputDecoration,
               ),
               const SizedBox(height: 20),
-              _buildLabel('경매 기간(시간)'),
-              DropdownButtonFormField<String>(
-                initialValue: viewModel.selectedDuration,
+              LabeledDropdown<String>(
+                label: '경매 기간(시간)',
+                value: viewModel.selectedDuration,
                 items: viewModel.durations
                     .map(
                       (e) => DropdownMenuItem<String>(
@@ -425,19 +195,14 @@ class ItemAddScreen extends StatelessWidget {
                   viewModel.setSelectedDuration(value);
                 },
                 decoration: _inputDecoration('4시간'),
-                icon: const Icon(Icons.keyboard_arrow_down_rounded),
-                dropdownColor: Colors.white,
-                style: const TextStyle(
-                  fontSize: 13,
-                  color: Colors.black87,
-                ),
               ),
               const SizedBox(height: 20),
-              _buildLabel('상품 설명'),
-              TextField(
+              LabeledTextField(
+                label: '상품 설명',
                 controller: viewModel.descriptionController,
                 maxLines: 5,
-                decoration: _inputDecoration('상품에 대한 상세한 설명을 입력하세요'),
+                decoration:
+                    _inputDecoration('상품에 대한 상세한 설명을 입력하세요'),
               ),
               const SizedBox(height: 80),
             ],
@@ -485,7 +250,7 @@ class ItemAddScreen extends StatelessWidget {
           ),
         ),
       ),
+    ),
     );
   }
 }
-//

--- a/lib/features/item/add/viewmodel/item_add_viewmodel.dart
+++ b/lib/features/item/add/viewmodel/item_add_viewmodel.dart
@@ -250,13 +250,17 @@ class ItemAddViewModel extends ChangeNotifier {
       return '시작가를 숫자로 입력해주세요.';
     }
 
-    if (startPrice < 1000) {
-      return '시작가는 1,000원 이상이어야 합니다.';
+    if (startPrice < 10000 || startPrice > 1400000) {
+      return '시작가는 10,000원 이상 1,400,000원 이하로 입력해주세요.';
     }
 
     if (useInstantPrice) {
       if (instantPrice == null) {
         return '즉시 입찰가를 숫자로 입력해주세요.';
+      }
+
+      if (instantPrice < 10000 || instantPrice > 1400000) {
+        return '즉시 입찰가는 10,000원 이상 1,400,000원 이하로 입력해주세요.';
       }
 
       if (instantPrice <= startPrice) {

--- a/lib/features/item/add/widget/item_add_image_section.dart
+++ b/lib/features/item/add/widget/item_add_image_section.dart
@@ -1,0 +1,177 @@
+import 'dart:io';
+
+import 'package:bidbird/core/utils/ui_set/border_radius.dart';
+import 'package:bidbird/core/utils/ui_set/colors.dart';
+import 'package:flutter/material.dart';
+
+import '../viewmodel/item_add_viewmodel.dart';
+
+class ItemAddImagesSection extends StatelessWidget {
+  const ItemAddImagesSection({
+    super.key,
+    required this.viewModel,
+    required this.onTapAdd,
+  });
+
+  final ItemAddViewModel viewModel;
+  final VoidCallback onTapAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 160,
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: BackgroundColor,
+        borderRadius: defaultBorder,
+        border: Border.all(color: BackgroundColor),
+      ),
+      child: Stack(
+        children: [
+          if (viewModel.selectedImages.isEmpty)
+            Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.file_upload_outlined,
+                    color: iconColor,
+                    size: 32,
+                  ),
+                  const SizedBox(height: 8),
+                  const Text(
+                    '이미지를 업로드하세요',
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: iconColor,
+                    ),
+                  ),
+                ],
+              ),
+            )
+          else
+            ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(
+                horizontal: 12,
+                vertical: 12,
+              ),
+              itemBuilder: (context, index) {
+                final image = viewModel.selectedImages[index];
+                final bool isPrimary = index == viewModel.primaryImageIndex;
+                return GestureDetector(
+                  onTap: () {
+                    viewModel.setPrimaryImage(index);
+                  },
+                  child: Stack(
+                    children: [
+                      ClipRRect(
+                        borderRadius: defaultBorder,
+                        child: Image.file(
+                          File(image.path),
+                          width: 120,
+                          height: 120,
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                      Positioned(
+                        top: 4,
+                        right: 4,
+                        child: GestureDetector(
+                          onTap: () {
+                            viewModel.removeImageAt(index);
+                          },
+                          child: Container(
+                            width: 20,
+                            height: 20,
+                            decoration: BoxDecoration(
+                              color: Colors.black54,
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                            alignment: Alignment.center,
+                            child: const Icon(
+                              Icons.close,
+                              size: 14,
+                              color: Colors.white,
+                            ),
+                          ),
+                        ),
+                      ),
+                      if (isPrimary)
+                        Positioned.fill(
+                          child: Center(
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 4,
+                              ),
+                              decoration: BoxDecoration(
+                                color: blueColor,
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                              child: const Text(
+                                '대표 이미지',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                );
+              },
+              separatorBuilder: (_, __) => const SizedBox(width: 8),
+              itemCount: viewModel.selectedImages.length,
+            ),
+          Positioned(
+            right: 8,
+            bottom: 8,
+            child: GestureDetector(
+              onTap: onTapAdd,
+              child: Container(
+                width: 32,
+                height: 32,
+                decoration: BoxDecoration(
+                  color: blueColor,
+                  borderRadius: BorderRadius.circular(defaultRadius),
+                ),
+                child: const Icon(
+                  Icons.add,
+                  color: Colors.white,
+                  size: 20,
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            left: 8,
+            bottom: 8,
+            child: Container(
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                color: blueColor,
+                borderRadius: BorderRadius.circular(defaultRadius),
+              ),
+              alignment: Alignment.center,
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  '${viewModel.selectedImages.length}/10',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 12,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/item/add/widget/item_add_price_section.dart
+++ b/lib/features/item/add/widget/item_add_price_section.dart
@@ -1,0 +1,117 @@
+import 'package:bidbird/core/utils/ui_set/colors.dart';
+import 'package:flutter/material.dart';
+
+import '../viewmodel/item_add_viewmodel.dart';
+
+class ItemAddPriceSection extends StatelessWidget {
+  const ItemAddPriceSection({
+    super.key,
+    required this.viewModel,
+    required this.inputDecoration,
+  });
+
+  final ItemAddViewModel viewModel;
+  final InputDecoration Function(String hint) inputDecoration;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Padding(
+                padding: EdgeInsets.only(bottom: 8.0),
+                child: Text(
+                  '시작가 (원)',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: textColor,
+                  ),
+                ),
+              ),
+              TextField(
+                controller: viewModel.startPriceController,
+                keyboardType: TextInputType.number,
+                decoration: inputDecoration('시작 가격 입력'),
+                onChanged: (value) {
+                  final formatted = viewModel.formatNumber(value);
+                  if (formatted != value) {
+                    viewModel.startPriceController.value = TextEditingValue(
+                      text: formatted,
+                      selection:
+                          TextSelection.collapsed(offset: formatted.length),
+                    );
+                  }
+                },
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(bottom: 4.0),
+                child: Row(
+                  children: [
+                    const Expanded(
+                      child: Text(
+                        '즉시 입찰가 (원)',
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w600,
+                          color: textColor,
+                        ),
+                      ),
+                    ),
+                    Checkbox(
+                      value: viewModel.useInstantPrice,
+                      activeColor: blueColor,
+                      checkColor: Colors.white,
+                      side: BorderSide(
+                        color: viewModel.useInstantPrice
+                            ? blueColor
+                            : Colors.black,
+                      ),
+                      visualDensity:
+                          const VisualDensity(horizontal: -4, vertical: -4),
+                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      onChanged: (value) {
+                        if (value == null) return;
+                        viewModel.setUseInstantPrice(value);
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              TextField(
+                controller: viewModel.instantPriceController,
+                keyboardType: TextInputType.number,
+                enabled: viewModel.useInstantPrice,
+                decoration: inputDecoration('즉시 입찰가 입력').copyWith(
+                  fillColor:
+                      viewModel.useInstantPrice ? Colors.white : BorderColor.withValues(alpha: 0.2),
+                ),
+                onChanged: (value) {
+                  final formatted = viewModel.formatNumber(value);
+                  if (formatted != value) {
+                    viewModel.instantPriceController.value = TextEditingValue(
+                      text: formatted,
+                      selection:
+                          TextSelection.collapsed(offset: formatted.length),
+                    );
+                  }
+                },
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/item/add/widget/labeled_dropdown.dart
+++ b/lib/features/item/add/widget/labeled_dropdown.dart
@@ -1,0 +1,52 @@
+import 'package:bidbird/core/utils/ui_set/colors.dart';
+import 'package:flutter/material.dart';
+
+class LabeledDropdown<T> extends StatelessWidget {
+  const LabeledDropdown({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.items,
+    required this.onChanged,
+    required this.decoration,
+  });
+
+  final String label;
+  final T? value;
+  final List<DropdownMenuItem<T>> items;
+  final ValueChanged<T?> onChanged;
+  final InputDecoration decoration;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (label.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8.0),
+            child: Text(
+              label,
+              style: const TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+                color: textColor,
+              ),
+            ),
+          ),
+        DropdownButtonFormField<T>(
+          initialValue: value,
+          items: items,
+          onChanged: onChanged,
+          decoration: decoration,
+          icon: const Icon(Icons.keyboard_arrow_down_rounded),
+          dropdownColor: Colors.white,
+          style: const TextStyle(
+            fontSize: 13,
+            color: Colors.black87,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/item/add/widget/labeled_text_field.dart
+++ b/lib/features/item/add/widget/labeled_text_field.dart
@@ -1,0 +1,42 @@
+import 'package:bidbird/core/utils/ui_set/colors.dart';
+import 'package:flutter/material.dart';
+
+class LabeledTextField extends StatelessWidget {
+  const LabeledTextField({
+    super.key,
+    required this.label,
+    required this.controller,
+    this.maxLines = 1,
+    this.decoration,
+  });
+
+  final String label;
+  final TextEditingController controller;
+  final int maxLines;
+  final InputDecoration? decoration;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8.0),
+          child: Text(
+            label,
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: textColor,
+            ),
+          ),
+        ),
+        TextField(
+          controller: controller,
+          maxLines: maxLines,
+          decoration: decoration,
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
1. 폴더·레이어 구조 정리
	• features/item/add 전체 구조를 data–model–viewmodel–screen–widget 계층으로 재정리했습니다.
	• Screen/Widget → ViewModel → UseCase → Repository → Datasource 방향으로 의존성을 명확히 분리했습니다.
	• 사용하지 않는 item_add_widgets.dart 파일을 제거했습니다.

2. 화면 및 위젯 리팩터링
	• ItemAddScreen을 구성 요소별로 세분화해 이미지/가격/텍스트필드/드롭다운 등을 독립 위젯으로 분리했습니다.
	• 공통 InputDecoration으로 스타일 정의를 통일했습니다.
	• 이미지 섹션, 가격 섹션, LabeledTextField, LabeledDropdown 컴포넌트를 정리했습니다.

3. 네비게이션 동작 개선
	• ItemAddScreen을 PopScope로 래핑해 뒤로가기 동작을 홈 화면으로 고정했습니다.

4. 입력 검증 로직 정비
	• 제목, 카테고리, 가격, 이미지, 설명에 대한 검증 조건을 명확히 정의했습니다.
	• 가격 범위, 즉시 입찰가 조건, 글자수 제한 등 모든 검증을 통합했습니다.
	• 실패 시 스낵바 메시지를 표시하고 성공 시 업로드 및 저장 절차 수행하도록 정리했습니다.