### PR TITLE
Feat/ 즉시구매 바텀시트 구조 분리 및 검증·의존성 정리

### DIFF
--- a/lib/features/item/bottom_sheet_buy_now_input/screen/bottom_sheet_buy_now_input.dart
+++ b/lib/features/item/bottom_sheet_buy_now_input/screen/bottom_sheet_buy_now_input.dart
@@ -6,6 +6,10 @@ import 'package:bidbird/features/item/bottom_sheet_buy_now_input/viewmodel/buy_n
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../widget/buy_now_header.dart';
+import '../widget/buy_now_price_card.dart';
+import '../widget/buy_now_primary_button.dart';
+
 class BuyNowInputBottomSheet extends StatelessWidget {
   const BuyNowInputBottomSheet({
     super.key,
@@ -40,96 +44,27 @@ class BuyNowInputBottomSheet extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                const Text(
-                  '즉시 구매',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-                IconButton(
-                  onPressed: () => Navigator.pop(context),
-                  icon: const Icon(
-                    Icons.close,
-                    size: 20,
-                  ),
-                  padding: EdgeInsets.zero,
-                  constraints: const BoxConstraints(),
-                ),
-              ],
-            ),
+            BuyNowHeader(onClose: () => Navigator.pop(context)),
             const SizedBox(height: 16),
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-              decoration: BoxDecoration(
-                color: Colors.white,
-                borderRadius: defaultBorder,
-                boxShadow: [
-                  BoxShadow(
-                    color: shadowLow,
-                    blurRadius: 10,
-                    offset: const Offset(0, 4),
-                  ),
-                ],
-              ),
-              child: Container(
-                width: double.infinity,
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
-                decoration: BoxDecoration(
-                  color: Colors.grey.shade200,
-                  borderRadius: defaultBorder,
-                ),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    const Text(
-                      '즉시 구매가',
-                      style: TextStyle(
-                        fontSize: 13,
-                        color: textColor,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      '${_formatPrice(buyNowPrice)}원',
-                      style: const TextStyle(
-                        fontSize: 20,
-                        fontWeight: FontWeight.w700,
-                        color: blueColor,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
+            BuyNowPriceCard(
+              formattedPrice: '${_formatPrice(buyNowPrice)}원',
             ),
             const SizedBox(height: 24),
-            SizedBox(
-              width: double.infinity,
-              height: 52,
-              child: ElevatedButton(
-                onPressed: viewModel.isSubmitting
-                    ? null
-                    : () => _showTermsDialog(context, viewModel),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: blueColor,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(defaultRadius),
-                  ),
-                ),
-                child: const Text(
-                  '즉시 구매하기',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                    color: Colors.white,
-                  ),
-                ),
-              ),
+            BuyNowPrimaryButton(
+              isSubmitting: viewModel.isSubmitting,
+              onPressed: () {
+                if (buyNowPrice < 10000 || buyNowPrice > 1400000) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text(
+                        '즉시 구매가는 10,000원 이상 1,400,000원 이하만 가능합니다.',
+                      ),
+                    ),
+                  );
+                  return;
+                }
+                _showTermsDialog(context, viewModel);
+              },
             ),
             const SizedBox(height: 8),
           ],

--- a/lib/features/item/bottom_sheet_buy_now_input/widget/buy_now_header.dart
+++ b/lib/features/item/bottom_sheet_buy_now_input/widget/buy_now_header.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class BuyNowHeader extends StatelessWidget {
+  const BuyNowHeader({
+    super.key,
+    required this.onClose,
+  });
+
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        const Text(
+          '즉시 구매',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        IconButton(
+          onPressed: onClose,
+          icon: const Icon(
+            Icons.close,
+            size: 20,
+          ),
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/item/bottom_sheet_buy_now_input/widget/buy_now_price_card.dart
+++ b/lib/features/item/bottom_sheet_buy_now_input/widget/buy_now_price_card.dart
@@ -1,0 +1,60 @@
+import 'package:bidbird/core/utils/ui_set/border_radius.dart';
+import 'package:bidbird/core/utils/ui_set/colors.dart';
+import 'package:flutter/material.dart';
+
+class BuyNowPriceCard extends StatelessWidget {
+  const BuyNowPriceCard({
+    super.key,
+    required this.formattedPrice,
+  });
+
+  final String formattedPrice;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: defaultBorder,
+        boxShadow: [
+          BoxShadow(
+            color: shadowLow,
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+        decoration: BoxDecoration(
+          color: Colors.grey.shade200,
+          borderRadius: defaultBorder,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              '즉시 구매가',
+              style: TextStyle(
+                fontSize: 13,
+                color: textColor,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              formattedPrice,
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w700,
+                color: blueColor,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/item/bottom_sheet_buy_now_input/widget/buy_now_primary_button.dart
+++ b/lib/features/item/bottom_sheet_buy_now_input/widget/buy_now_primary_button.dart
@@ -1,0 +1,39 @@
+import 'package:bidbird/core/utils/ui_set/border_radius.dart';
+import 'package:bidbird/core/utils/ui_set/colors.dart';
+import 'package:flutter/material.dart';
+
+class BuyNowPrimaryButton extends StatelessWidget {
+  const BuyNowPrimaryButton({
+    super.key,
+    required this.isSubmitting,
+    required this.onPressed,
+  });
+
+  final bool isSubmitting;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 52,
+      child: ElevatedButton(
+        onPressed: isSubmitting ? null : onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: blueColor,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(defaultRadius),
+          ),
+        ),
+        child: const Text(
+          '즉시 구매하기',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/item/detail/screen/widgets/item_bottom_action_bar.dart
+++ b/lib/features/item/detail/screen/widgets/item_bottom_action_bar.dart
@@ -1,13 +1,14 @@
 import 'package:bidbird/core/managers/supabase_manager.dart';
 import 'package:bidbird/core/utils/ui_set/border_radius.dart';
 import 'package:bidbird/core/utils/ui_set/colors.dart';
-import 'package:bidbird/features/item/bottom_sheet_buy_now_input/screen/bottom_sheet_buy_now_input.dart';
-import 'package:bidbird/features/item/bottom_sheet_buy_now_input/viewmodel/buy_now_input_viewmodel.dart';
-import 'package:bidbird/features/item/detail/model/item_detail_entity.dart';
-import 'package:bidbird/features/item/bottom_sheet_price_Input/screen/price_input_screen.dart';
-import 'package:bidbird/features/item/bottom_sheet_price_Input/viewmodel/price_input_viewmodel.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
+import '../../../bottom_sheet_buy_now_input/screen/bottom_sheet_buy_now_input.dart';
+import '../../../bottom_sheet_buy_now_input/viewmodel/buy_now_input_viewmodel.dart';
+import '../../../bottom_sheet_price_Input/screen/price_input_screen.dart';
+import '../../../bottom_sheet_price_Input/viewmodel/price_input_viewmodel.dart';
+import '../../model/item_detail_entity.dart';
 
 class ItemBottomActionBar extends StatefulWidget {
   const ItemBottomActionBar({required this.item, required this.isMyItem, super.key});


### PR DESCRIPTION
1. 즉시구매 바텀시트 구조 분리
	• features/item/bottom_sheet_buy_now_input 구조를 screen–viewmodel–model–data–widget 단위로 분리했습니다.
	• BuyNowInputBottomSheet, BuyNowInputViewModel, BuyNowBidRequest, Repository/Datasource, Header·PriceCard·PrimaryButton 위젯으로 구성했습니다.

2. 즉시구매 금액 프론트 검증 추가
	• BuyNowPrimaryButton.onPressed에서 금액 범위를 체크하도록 수정했습니다.
	• 10,000–1,400,000원 범위를 벗어나면 SnackBar만 출력하고 약관 다이얼로그를 호출하지 않도록 처리했습니다.
	• 정상 범위일 때만 약관 → 확인 → viewModel.placeBid → 완료 팝업으로 이어지도록 유지했습니다.

3. import 및 의존성 정리
	• bottom_sheet_buy_now_input.dart에서 ViewModel을 패키지 경로 기반으로 정리했습니다.
	• item_bottom_action_bar 등 관련 파일에서 중복 import 및 불필요 참조를 제거했습니다.