### PR TITLE
Feat/ 즉시 구매 상태 및 참여 입찰 카운트 로직 정비

### DIFF
--- a/lib/features/item/detail/data/datasource/item_detail_datasource.dart
+++ b/lib/features/item/detail/data/datasource/item_detail_datasource.dart
@@ -123,6 +123,8 @@ class ItemDetailDatasource {
           .from('bid_log')
           .select('id')
           .eq('item_id', itemId)
+          .isFilter('instant_buy_triggered_at', null)
+          .neq('bid_price', 0)
           .count(CountOption.exact);
       return countResponse.count;
     } catch (e) {

--- a/lib/features/item/detail/screen/widgets/item_bottom_action_bar.dart
+++ b/lib/features/item/detail/screen/widgets/item_bottom_action_bar.dart
@@ -294,25 +294,50 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
       );
     }
 
-    // 즉시 구매 진행 중(1006)인 경우에는 최고 입찰자 여부와 상관없이 결제 버튼을 우선 노출
+    // 즉시 구매 진행 중(1006)인 경우
+    // - 즉시 구매를 건 사용자(현재 최고 입찰자)는 '결제하러 가기' 버튼 노출
+    // - 그 외 사용자는 안내 문구만 노출
     if (isBuyNowInProgress && !isBuyNowCompleted) {
-      return ElevatedButton(
-        onPressed: () {
-          debugPrint('[ItemBottomActionBar] 결제하러 가기 버튼 탭');
-          // TODO: 결제 화면으로 이동하는 로직 연동
-        },
-        style: ElevatedButton.styleFrom(
-          backgroundColor: blueColor,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8.7),
+      if (isTopBidder) {
+        return ElevatedButton(
+          onPressed: () {
+            debugPrint('[ItemBottomActionBar] 결제하러 가기 버튼 탭');
+            // TODO: 결제 화면으로 이동하는 로직 연동
+          },
+          style: ElevatedButton.styleFrom(
+            backgroundColor: blueColor,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8.7),
+            ),
           ),
+          child: const Text(
+            '결제하러 가기',
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: Colors.white,
+            ),
+          ),
+        );
+      }
+
+      // 다른 사용자는 결제 대기 안내 문구만 표시
+      return Container(
+        height: 40,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        decoration: BoxDecoration(
+          color: BackgroundColor,
+          borderRadius: BorderRadius.circular(8.7),
+          border: Border.all(color: BorderColor),
         ),
-        child: const Text(
-          '결제하러 가기',
-          style: TextStyle(
-            fontSize: 13,
-            fontWeight: FontWeight.w600,
-            color: Colors.white,
+        child: const Center(
+          child: Text(
+            '즉시 구매 결제 대기중입니다',
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: TopBidderTextColor,
+            ),
           ),
         ),
       );
@@ -387,7 +412,7 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
 
     // 1) 이미 최고 입찰자인 경우
     if (isTopBidder) {
-      reason = '이미 이 상품의 최고 입찰자입니다';
+      reason = '최고 입찰자입니다';
     } else {
       // 2) 상태 코드별 상세 사유
       switch (statusCode) {
@@ -400,10 +425,10 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
           reason = '경매가 종료되었습니다.';
           break;
         case 1006: // 즉시 구매 진행 중
-          reason = '즉시 구매 중인 상품입니다';
+          reason = '즉시 구매 결제 대기중입니다';
           break;
         case 1007: // 즉시 구매 완료
-          reason = '즉시 구매가 완료된 상품입니다';
+          reason = '즉시 구매되었습니다';
           break;
         case 1011: // 거래 정지
           reason = '거래가 정지된 상품입니다';


### PR DESCRIPTION
1. 참여 입찰 카운트 로직 수정
	• bid_log 기준으로 다음 조건에 맞는 레코드만 집계하도록 변경했습니다.
	• item_id 일치
	• instant_buy_triggered_at IS NULL (즉시 구매 트리거 제외)
	• bid_price != 0 (0원 로그 제외)
	• “참여 입찰 n건”이 실제 금액이 들어간 일반 입찰 수만 반영하도록 기준을 정리했습니다.
2. 즉시 구매 상태별 버튼·문구 로직 변경
	• 상태코드 1006 (즉시 구매 진행 중)
	• 현재 최고 입찰자(즉시 구매 수행자): 결제하러 가기 버튼 노출
	• 기타 사용자: 버튼 숨김, 즉시 구매 결제 대기중입니다 안내 문구만 노출
	• 상태코드 1007 (즉시 구매 완료)
	• 모든 사용자에게 즉시 구매되었습니다 문구만 표시하고 추가 입찰·즉시 구매는 불가하도록 처리했습니다.
3. 비활성 사유(reason) 메시지 통일
	• 상태코드별 비활성 사유 텍스트를 정리했습니다.
	• 1006: 즉시 구매 결제 대기중입니다
	• 1007: 즉시 구매되었습니다
	• 버튼 비활성 영역과 안내 문구가 동일한 메시지를 사용하도록 통일했습니다.