### PR TITLE
Chore/ PopScope 경고 제거 및 미사용 코드 정리

### DIFF
--- a/lib/features/item/add/screen/item_add_screen.dart
+++ b/lib/features/item/add/screen/item_add_screen.dart
@@ -78,7 +78,7 @@ class ItemAddScreen extends StatelessWidget {
 
     return PopScope(
       canPop: false,
-      onPopInvoked: (didPop) {
+      onPopInvokedWithResult: (didPop, result) {
         if (!didPop) {
           context.go('/home');
         }

--- a/lib/features/item/detail/data/datasource/item_detail_datasource.dart
+++ b/lib/features/item/detail/data/datasource/item_detail_datasource.dart
@@ -132,25 +132,6 @@ class ItemDetailDatasource {
     return images;
   }
 
-  Future<int> _fetchBiddingCount(
-    String itemId,
-    Map<String, dynamic> row,
-  ) async {
-    try {
-      final countResponse = await _supabase
-          .from('bid_log')
-          .select('id')
-          .eq('item_id', itemId)
-          .isFilter('instant_buy_triggered_at', null)
-          .neq('bid_price', 0)
-          .count(CountOption.exact);
-      return countResponse.count;
-    } catch (e) {
-      return (row['bidding_count'] as int?) ?? 0;
-    }
-  }
-
-
   Future<bool> checkIsFavorite(String itemId) async {
     final user = _supabase.auth.currentUser;
     if (user == null) return false;

--- a/lib/features/item/detail/screen/widgets/item_bottom_action_bar.dart
+++ b/lib/features/item/detail/screen/widgets/item_bottom_action_bar.dart
@@ -266,7 +266,6 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
     final bool isAuctionEnded =
         statusCode == 321 || statusCode == 322 || statusCode == 323;
 
-    final bool isAuctionPending = statusCode == 300;
     final bool isAuctionActive = statusCode == 310;
     final bool isBuyNowInProgress = statusCode == 311;
     final bool isBuyNowCompleted = statusCode == 322;


### PR DESCRIPTION
1. ItemAddScreen PopScope 경고 해결
	• onPopInvoked 사용 부분을 onPopInvokedWithResult로 교체했습니다.
	• 뒤로가기 시 didPop == false이면 /home으로 이동하는 기존 동작은 그대로 유지했습니다.
2. ItemDetailDatasource 미사용 메서드 제거
	• lib/features/item/detail/data/datasource/item_detail_datasource.dart 내 실제로 호출되지 않는 _fetchBiddingCount private 메서드를 삭제했습니다.
	• 입찰 수는 auctions 테이블 기반 로직으로만 사용되도록 중복 코드를 정리했습니다.
3. ItemBottomActionBar 미사용 변수 제거
	• item_bottom_action_bar.dart의 _buildBidButton 내부에서 사용되지 않는 isAuctionPending 변수를 제거했습니다.