### PR TITLE
Feat/ 매물 등록·상세·거래내역 흐름 개선

### DIFF
--- a/lib/features/item/add/viewmodel/item_add_viewmodel.dart
+++ b/lib/features/item/add/viewmodel/item_add_viewmodel.dart
@@ -137,11 +137,11 @@ class ItemAddViewModel extends ChangeNotifier {
     final supabase = SupabaseManager.shared.supabase;
     try {
       final Map<String, dynamic> row = await supabase
-          .from('items')
+          .from('items_detail')
           .select(
             'title, description, start_price, buy_now_price, keyword_type, auction_duration_hours',
           )
-          .eq('id', itemId)
+          .eq('item_id', itemId)
           .single();
 
       titleController.text = (row['title'] ?? '').toString();
@@ -347,8 +347,21 @@ class ItemAddViewModel extends ChangeNotifier {
       barrierDismissible: false,
       builder: (_) {
         return const Center(
-          child: CircularProgressIndicator(
-            valueColor: AlwaysStoppedAnimation<Color>(blueColor),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CircularProgressIndicator(
+                valueColor: AlwaysStoppedAnimation<Color>(blueColor),
+              ),
+              SizedBox(height: 12),
+              Text(
+                '로딩중',
+                style: TextStyle(
+                  fontSize: 14,
+                  color: textColor,
+                ),
+              ),
+            ],
           ),
         );
       },

--- a/lib/features/item/bottom_sheet_buy_now_input/screen/bottom_sheet_buy_now_input.dart
+++ b/lib/features/item/bottom_sheet_buy_now_input/screen/bottom_sheet_buy_now_input.dart
@@ -1,6 +1,7 @@
 import 'package:bidbird/core/widgets/components/pop_up/ask_popup.dart';
 import 'package:bidbird/core/widgets/components/pop_up/confirm_check_cancel_popup.dart';
 import 'package:bidbird/features/item/bottom_sheet_buy_now_input/viewmodel/buy_now_input_viewmodel.dart';
+import 'package:bidbird/features/item/detail/viewmodel/item_detail_viewmodel.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -141,6 +142,15 @@ class BuyNowInputBottomSheet extends StatelessWidget {
           yesText: '확인',
           yesLogic: () async {
             Navigator.pop(dialogContext);
+            if (!parentContext.mounted) return;
+
+            // 상세 화면 강제 새로고침
+            final detailViewModel =
+                parentContext.read<ItemDetailViewModel?>();
+            if (detailViewModel != null) {
+              await detailViewModel.loadItemDetail();
+            }
+
             if (parentContext.mounted) {
               Navigator.pop(parentContext);
             }

--- a/lib/features/item/item_registration_list/screen/item_registration_list_screen.dart
+++ b/lib/features/item/item_registration_list/screen/item_registration_list_screen.dart
@@ -26,7 +26,19 @@ class RegistrationScreen extends StatelessWidget {
 
   Widget _buildBody(BuildContext context, RegistrationViewModel viewModel) {
     if (viewModel.isLoading) {
-      return const Center(child: CircularProgressIndicator());
+      return const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(),
+            SizedBox(height: 12),
+            Text(
+              '로딩중',
+              style: TextStyle(fontSize: 14, color: textColor),
+            ),
+          ],
+        ),
+      );
     }
 
     if (viewModel.error != null) {


### PR DESCRIPTION
1. ItemAddScreen 뒤로가기 및 로딩 UX 개선
	• PopScope deprecation 대응 (onPopInvokedWithResult 사용)으로 경고 제거 후, 뒤로가기 시 /home 이동 동작 유지.
	• 매물 등록 진행 중 로딩 다이얼로그에 로딩중 텍스트를 추가해 상태를 명확히 표시.

2. 매물 등록 후 수정 진입 시 기존 값 로딩
	• 등록 대기 목록에서 사용하는 id를 items_detail.item_id로 통일.
	•items_detail에서 제목/설명/가격/옵션을 조회해, 확인 화면 → 수정하기 진입 시 기존 값이 채워진 상태로 열리도록 수정.

3. 입찰·거래 상태 로직 및 표기 보정
	• current_trade 쪽에서 auctions의 auction_status_code, trade_status_code를 함께 조회해, 즉시 구매 시도(431) 이후 상태를 다음처럼 구분:
	• 즉시 구매 실패 후 경매 롤백: 경매 진행 중
	• 즉시 구매 최종 완료: 즉시 구매 완료
	• 그 외 즉시 구매 성공 진행 중: 즉시 구매 낙찰
	• 상대방 거래 내역 조회를 items_detail + auctions 조합으로 변경하고, 상태 코드를 매핑해 입찰 중/판매 완료/구매 완료/유찰/거래 완료 등으로 라벨링.

4. 참여 입찰/입찰 내역 기준 정리
	• 참여 입찰 수는 bid_log 기준으로 다음 조건만 카운트하도록 정리:
	• item_id 일치
	• instant_buy_triggered_at IS NULL (즉시 구매 트리거 로그 제외)
	• bid_price != 0 (0원 로그 제외)
	• 하단 “현재 입찰 내역”도 0원 입찰을 숨겨, 참여 입찰 수와 리스트의 기준이 일관되도록 정리.

5. 로딩 상태 시 사용자 피드백 보강
	• 매물 등록 목록 화면에서 ViewModel.isLoading 시, 스피너 아래에 로딩중 문구를 함께 보여주도록 처리.
	• 최초 매물 등록 submit 시에도 로딩 다이얼로그에 로딩중을 표시해 네트워크·업로드 중임을 명확히 전달.

6. 즉시 구매 플로우 후 상세 화면 최신 상태 반영
	• 즉시 구매 바텀시트에서 성공 팝업 확인 시 ItemDetailViewModel.loadItemDetail를 호출해, 결제/즉시 구매 결과가 상세 화면에 바로 반영되도록 수정.
	• 팝업 → 상세 재로딩 → 바텀시트 순서로 닫히도록 처리해 상태 꼬임을 방지.