### PR TITLE
Feat/ 결제 제한 검증·상세 리프레시·로딩 UI 개선 및 매물 수정 로직 오류 해결

### DIFF
--- a/lib/features/item/add/data/datasources/edit_item_remote_datasource.dart
+++ b/lib/features/item/add/data/datasources/edit_item_remote_datasource.dart
@@ -1,0 +1,43 @@
+import 'package:bidbird/core/managers/supabase_manager.dart';
+import 'package:bidbird/features/item/add/model/edit_item_entity.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class EditItemRemoteDataSource {
+  EditItemRemoteDataSource({SupabaseClient? supabase})
+      : _supabase = supabase ?? SupabaseManager.shared.supabase;
+
+  final SupabaseClient _supabase;
+
+  Future<EditItemEntity> fetchItemForEdit(String itemId) async {
+    final Map<String, dynamic> row = await _supabase
+        .from('items_detail')
+        .select(
+          'title, description, start_price, buy_now_price, keyword_type, auction_duration_hours',
+        )
+        .eq('item_id', itemId)
+        .single();
+
+    final List<dynamic> imageRows = await _supabase
+        .from('item_images')
+        .select('image_url, sort_order')
+        .eq('item_id', itemId)
+        .order('sort_order');
+
+    final List<String> imageUrls = imageRows
+        .cast<Map<String, dynamic>>()
+        .map((e) => (e['image_url'] ?? '').toString())
+        .where((url) => url.isNotEmpty)
+        .toList();
+
+    return EditItemEntity(
+      title: (row['title'] ?? '').toString(),
+      description: (row['description'] ?? '').toString(),
+      startPrice: (row['start_price'] as num?)?.toInt() ?? 0,
+      buyNowPrice: (row['buy_now_price'] as num?)?.toInt() ?? 0,
+      keywordTypeId: (row['keyword_type'] as num?)?.toInt() ?? 0,
+      auctionDurationHours:
+          (row['auction_duration_hours'] as num?)?.toInt() ?? 4,
+      imageUrls: imageUrls,
+    );
+  }
+}

--- a/lib/features/item/add/data/datasources/image_upload_datasource.dart
+++ b/lib/features/item/add/data/datasources/image_upload_datasource.dart
@@ -1,0 +1,8 @@
+import 'package:bidbird/core/managers/cloudinary_manager.dart';
+import 'package:image_picker/image_picker.dart';
+
+class ImageUploadDataSource {
+  Future<List<String>> uploadImages(List<XFile> files) {
+    return CloudinaryManager.shared.uploadImageListToCloudinary(files);
+  }
+}

--- a/lib/features/item/add/data/datasources/keyword_remote_datasource.dart
+++ b/lib/features/item/add/data/datasources/keyword_remote_datasource.dart
@@ -1,0 +1,27 @@
+import 'package:bidbird/core/managers/supabase_manager.dart';
+import 'package:bidbird/features/item/add/model/keyword_type_entity.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class KeywordRemoteDataSource {
+  KeywordRemoteDataSource({SupabaseClient? supabase})
+      : _supabase = supabase ?? SupabaseManager.shared.supabase;
+
+  final SupabaseClient _supabase;
+
+  Future<List<KeywordTypeEntity>> fetchKeywordTypes() async {
+    final List<dynamic> data = await _supabase
+        .from('code_keyword_type')
+        .select('id, title')
+        .order('id');
+
+    return data
+        .cast<Map<String, dynamic>>()
+        .map(
+          (e) => KeywordTypeEntity(
+            id: (e['id'] as num).toInt(),
+            title: (e['title'] ?? '').toString(),
+          ),
+        )
+        .toList();
+  }
+}

--- a/lib/features/item/add/data/repository/edit_item_repository.dart
+++ b/lib/features/item/add/data/repository/edit_item_repository.dart
@@ -1,0 +1,16 @@
+import 'package:bidbird/features/item/add/model/edit_item_entity.dart';
+import 'package:bidbird/features/item/add/model/edit_item_gateway.dart';
+
+import 'package:bidbird/features/item/add/data/datasources/edit_item_remote_datasource.dart';
+
+class EditItemGatewayImpl implements EditItemGateway {
+  EditItemGatewayImpl({EditItemRemoteDataSource? dataSource})
+      : _dataSource = dataSource ?? EditItemRemoteDataSource();
+
+  final EditItemRemoteDataSource _dataSource;
+
+  @override
+  Future<EditItemEntity> fetchItemForEdit(String itemId) {
+    return _dataSource.fetchItemForEdit(itemId);
+  }
+}

--- a/lib/features/item/add/data/repository/image_upload_repository.dart
+++ b/lib/features/item/add/data/repository/image_upload_repository.dart
@@ -1,0 +1,16 @@
+import 'package:image_picker/image_picker.dart';
+
+import 'package:bidbird/features/item/add/data/datasources/image_upload_datasource.dart';
+import 'package:bidbird/features/item/add/model/image_upload_gateway.dart';
+
+class ImageUploadGatewayImpl implements ImageUploadGateway {
+  ImageUploadGatewayImpl({ImageUploadDataSource? dataSource})
+      : _dataSource = dataSource ?? ImageUploadDataSource();
+
+  final ImageUploadDataSource _dataSource;
+
+  @override
+  Future<List<String>> uploadImages(List<XFile> files) {
+    return _dataSource.uploadImages(files);
+  }
+}

--- a/lib/features/item/add/data/repository/item_add_repository.dart
+++ b/lib/features/item/add/data/repository/item_add_repository.dart
@@ -1,14 +1,16 @@
 import 'package:bidbird/features/item/add/model/item_add_entity.dart';
+import 'package:bidbird/features/item/add/model/item_add_gateway.dart';
 import 'package:bidbird/features/item/item_registration_list/model/item_registration_entity.dart';
 
 import '../datasources/supabase_item_add_datasource.dart';
 
-class ItemAddRepositoryImpl {
-  ItemAddRepositoryImpl({SupabaseItemAddDatasource? datasource})
+class ItemAddGatewayImpl implements ItemAddGateway {
+  ItemAddGatewayImpl({SupabaseItemAddDatasource? datasource})
       : _datasource = datasource ?? SupabaseItemAddDatasource();
 
   final SupabaseItemAddDatasource _datasource;
 
+  @override
   Future<ItemRegistrationData> saveItem({
     required ItemAddEntity entity,
     required List<String> imageUrls,

--- a/lib/features/item/add/data/repository/keyword_repository.dart
+++ b/lib/features/item/add/data/repository/keyword_repository.dart
@@ -1,0 +1,15 @@
+import 'package:bidbird/features/item/add/data/datasources/keyword_remote_datasource.dart';
+import 'package:bidbird/features/item/add/model/keyword_gateway.dart';
+import 'package:bidbird/features/item/add/model/keyword_type_entity.dart';
+
+class KeywordGatewayImpl implements KeywordGateway {
+  KeywordGatewayImpl({KeywordRemoteDataSource? dataSource})
+      : _dataSource = dataSource ?? KeywordRemoteDataSource();
+
+  final KeywordRemoteDataSource _dataSource;
+
+  @override
+  Future<List<KeywordTypeEntity>> fetchKeywordTypes() {
+    return _dataSource.fetchKeywordTypes();
+  }
+}

--- a/lib/features/item/add/model/add_item_usecase.dart
+++ b/lib/features/item/add/model/add_item_usecase.dart
@@ -1,11 +1,11 @@
 import 'package:bidbird/features/item/add/model/item_add_entity.dart';
-import 'package:bidbird/features/item/add/data/repository/item_add_repository.dart';
+import 'package:bidbird/features/item/add/model/item_add_gateway.dart';
 import 'package:bidbird/features/item/item_registration_list/model/item_registration_entity.dart';
 
 class AddItemUseCase {
-  AddItemUseCase(this._repository);
+  AddItemUseCase(this._gateway);
 
-  final ItemAddRepositoryImpl _repository;
+  final ItemAddGateway _gateway;
 
   Future<ItemRegistrationData> call({
     required ItemAddEntity entity,
@@ -13,7 +13,7 @@ class AddItemUseCase {
     required int primaryImageIndex,
     String? editingItemId,
   }) {
-    return _repository.saveItem(
+    return _gateway.saveItem(
       entity: entity,
       imageUrls: imageUrls,
       primaryImageIndex: primaryImageIndex,

--- a/lib/features/item/add/model/edit_item_entity.dart
+++ b/lib/features/item/add/model/edit_item_entity.dart
@@ -1,0 +1,19 @@
+class EditItemEntity {
+  EditItemEntity({
+    required this.title,
+    required this.description,
+    required this.startPrice,
+    required this.buyNowPrice,
+    required this.keywordTypeId,
+    required this.auctionDurationHours,
+    required this.imageUrls,
+  });
+
+  final String title;
+  final String description;
+  final int startPrice;
+  final int buyNowPrice;
+  final int keywordTypeId;
+  final int auctionDurationHours;
+  final List<String> imageUrls;
+}

--- a/lib/features/item/add/model/edit_item_gateway.dart
+++ b/lib/features/item/add/model/edit_item_gateway.dart
@@ -1,0 +1,5 @@
+import 'edit_item_entity.dart';
+
+abstract class EditItemGateway {
+  Future<EditItemEntity> fetchItemForEdit(String itemId);
+}

--- a/lib/features/item/add/model/get_edit_item_usecase.dart
+++ b/lib/features/item/add/model/get_edit_item_usecase.dart
@@ -1,0 +1,12 @@
+import 'edit_item_entity.dart';
+import 'edit_item_gateway.dart';
+
+class GetEditItemUseCase {
+  GetEditItemUseCase(this._gateway);
+
+  final EditItemGateway _gateway;
+
+  Future<EditItemEntity> call(String itemId) {
+    return _gateway.fetchItemForEdit(itemId);
+  }
+}

--- a/lib/features/item/add/model/get_keyword_types_usecase.dart
+++ b/lib/features/item/add/model/get_keyword_types_usecase.dart
@@ -1,0 +1,12 @@
+import 'keyword_gateway.dart';
+import 'keyword_type_entity.dart';
+
+class GetKeywordTypesUseCase {
+  GetKeywordTypesUseCase(this._gateway);
+
+  final KeywordGateway _gateway;
+
+  Future<List<KeywordTypeEntity>> call() {
+    return _gateway.fetchKeywordTypes();
+  }
+}

--- a/lib/features/item/add/model/image_upload_gateway.dart
+++ b/lib/features/item/add/model/image_upload_gateway.dart
@@ -1,0 +1,5 @@
+import 'package:image_picker/image_picker.dart';
+
+abstract class ImageUploadGateway {
+  Future<List<String>> uploadImages(List<XFile> files);
+}

--- a/lib/features/item/add/model/item_add_gateway.dart
+++ b/lib/features/item/add/model/item_add_gateway.dart
@@ -1,0 +1,12 @@
+import 'package:bidbird/features/item/add/model/item_add_entity.dart';
+import 'package:bidbird/features/item/item_registration_list/model/item_registration_entity.dart';
+
+/// 도메인 레이어용 게이트웨이 인터페이스
+abstract class ItemAddGateway {
+  Future<ItemRegistrationData> saveItem({
+    required ItemAddEntity entity,
+    required List<String> imageUrls,
+    required int primaryImageIndex,
+    String? editingItemId,
+  });
+}

--- a/lib/features/item/add/model/keyword_gateway.dart
+++ b/lib/features/item/add/model/keyword_gateway.dart
@@ -1,0 +1,5 @@
+import 'keyword_type_entity.dart';
+
+abstract class KeywordGateway {
+  Future<List<KeywordTypeEntity>> fetchKeywordTypes();
+}

--- a/lib/features/item/add/model/keyword_type_entity.dart
+++ b/lib/features/item/add/model/keyword_type_entity.dart
@@ -1,0 +1,9 @@
+class KeywordTypeEntity {
+  KeywordTypeEntity({
+    required this.id,
+    required this.title,
+  });
+
+  final int id;
+  final String title;
+}

--- a/lib/features/item/add/model/upload_images_usecase.dart
+++ b/lib/features/item/add/model/upload_images_usecase.dart
@@ -1,0 +1,13 @@
+import 'package:image_picker/image_picker.dart';
+
+import 'image_upload_gateway.dart';
+
+class UploadImagesUseCase {
+  UploadImagesUseCase(this._gateway);
+
+  final ImageUploadGateway _gateway;
+
+  Future<List<String>> call(List<XFile> files) {
+    return _gateway.uploadImages(files);
+  }
+}

--- a/lib/features/item/bottom_sheet_price_Input/screen/price_input_screen.dart
+++ b/lib/features/item/bottom_sheet_price_Input/screen/price_input_screen.dart
@@ -1,6 +1,7 @@
 import 'package:bidbird/core/utils/ui_set/border_radius_style.dart';
 import 'package:bidbird/core/utils/ui_set/colors_style.dart';
 import 'package:bidbird/core/widgets/components/pop_up/ask_popup.dart';
+import 'package:bidbird/features/item/detail/viewmodel/item_detail_viewmodel.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -352,6 +353,15 @@ class _BidBottomSheetState extends State<BidBottomSheet> {
           yesText: '확인',
           yesLogic: () async {
             Navigator.pop(dialogContext);
+            if (!parentContext.mounted) return;
+
+            // 상세 화면 강제 새로고침
+            final detailViewModel =
+                parentContext.read<ItemDetailViewModel?>();
+            if (detailViewModel != null) {
+              await detailViewModel.loadItemDetail();
+            }
+
             if (parentContext.mounted) {
               Navigator.pop(parentContext);
             }

--- a/lib/features/item/item_registration_list/screen/item_registration_list_screen.dart
+++ b/lib/features/item/item_registration_list/screen/item_registration_list_screen.dart
@@ -32,9 +32,21 @@ class RegistrationScreen extends StatelessWidget {
           children: [
             CircularProgressIndicator(),
             SizedBox(height: 12),
-            Text(
-              '로딩중',
-              style: TextStyle(fontSize: 14, color: textColor),
+            ClipRect(
+              child: Align(
+                alignment: Alignment.topCenter,
+                heightFactor: 0.8,
+                child: Text(
+                  '로딩중',
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: textColor,
+                    decoration: TextDecoration.none,
+                    decorationColor: Colors.transparent,
+                    decorationThickness: 0,
+                  ),
+                ),
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
1. 결제 제한(3회 실패) 시 즉시 구매 차단
	• bottom_sheet_buy_now_input에서 onPressed 내부 로직에 결제 제한 검증을 추가했습니다.
	• Supabase bid_restriction 조회 후 is_blocked == true이면 스낵바만 출력하고 즉시 구매 플로우 진입을 중단합니다.
	• 로그인되지 않은 경우에도 스낵바 표시 후 차단합니다.
	• 상세 화면(ItemBottomActionBar)에서 이미 노출되는 제한 문구와 동일한 정책으로 작동합니다.

2. 일반 입찰 완료 후 상세 화면 즉시 갱신
	• bottom_sheet_price_input의 _processBid 성공 처리에서 상세 화면 강제 리프레시를 수행하도록 했습니다.
	• 즉시 구매 플로우와 동일한 UX로 통일해 입찰 후 상태 반영 문제를 해결했습니다.

3. 매물 수정 시 새 매물이 중복 생성되던 오류 해결
	• 수정 플로우에서 항상 신규 insert(register_item)를 호출하던 구조를 수정했습니다.
	• editingItemId가 존재하면 기존 items_detail을 update하고 item_images만 삭제 후 재삽입하도록 변경했습니다.
	• 신규 등록과 수정 로직을 분리해 하나의 매물이 중복 생성되는 문제를 제거했습니다.