### PR TITLE
Feat/ 매물 등록 플로우 개선 및 중복 등록 차단

### DIFF
--- a/lib/features/item/add/viewmodel/item_add_viewmodel.dart
+++ b/lib/features/item/add/viewmodel/item_add_viewmodel.dart
@@ -409,17 +409,21 @@ class ItemAddViewModel extends ChangeNotifier {
       if (!context.mounted) return;
       await showDialog(
         context: context,
-        builder: (_) => AskPopup(
-          content: '매물 등록 확인 화면으로 이동하여 최종 등록을 진행해 주세요.',
-          yesText: '이동하기',
-          yesLogic: () async {
-            navigator.pop();
-            if (!context.mounted) return;
-            WidgetsBinding.instance.addPostFrameCallback((_) {
+        barrierDismissible: false,
+        builder: (_) => WillPopScope(
+          onWillPop: () async => false,
+          child: AskPopup(
+            content: '매물 등록 확인 화면으로 이동하여 최종 등록을 진행해 주세요.',
+            yesText: '이동하기',
+            yesLogic: () async {
+              navigator.pop();
               if (!context.mounted) return;
-              context.push('/add_item/item_registration_list');
-            });
-          },
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (!context.mounted) return;
+                context.go('/add_item/item_registration_list');
+              });
+            },
+          ),
         ),
       );
     } catch (e) {


### PR DESCRIPTION
1. 등록 화면에서 뒤로가기 동작 강제 제어
	• ItemAddScreen을 PopScope로 감싸 OS 뒤로가기가 눌려도 pop이 발생하지 않도록 했습니다.

2. 등록 성공 팝업에서 뒤로가기 완전 차단
	• 성공 팝업을 barrierDismissible: false 로 설정해 외부 터치로 닫히지 않도록 했습니다.
	• 팝업 단계에서는 오로지 버튼 액션으로만 진행이 가능하도록 UX를 강제했습니다.

3. 팝업 버튼으로만 등록 확인 화면으로 이동
	• go() 사용으로 기존 라우트가 교체되므로 등록 화면으로 돌아갈 수 없으며, 동일 매물의 재저장 플로우를 원천 차단했습니다.
