### PR TITLE
Feat/ 매물 등록 카테고리·기간 처리 개선 및 등록 완료 팝업 UI 정비

### DIFF
--- a/lib/features/item/add/data/datasources/edit_item_remote_datasource.dart
+++ b/lib/features/item/add/data/datasources/edit_item_remote_datasource.dart
@@ -36,7 +36,7 @@ class EditItemRemoteDataSource {
       buyNowPrice: (row['buy_now_price'] as num?)?.toInt() ?? 0,
       keywordTypeId: (row['keyword_type'] as num?)?.toInt() ?? 0,
       auctionDurationHours:
-          (row['auction_duration_hours'] as num?)?.toInt() ?? 4,
+          (((row['auction_duration_hours'] as num?)?.toInt() ?? 240) ~/ 60),
       imageUrls: imageUrls,
     );
   }

--- a/lib/features/item/add/viewmodel/item_add_viewmodel.dart
+++ b/lib/features/item/add/viewmodel/item_add_viewmodel.dart
@@ -67,9 +67,17 @@ class ItemAddViewModel extends ChangeNotifier {
 
     try {
       final types = await _getKeywordTypesUseCase();
+      final filtered = types.where((e) => e.title != '전체');
       keywordTypes
         ..clear()
-        ..addAll(types.map((e) => {'id': e.id, 'title': e.title}));
+        ..addAll(filtered.map((e) => {'id': e.id, 'title': e.title}));
+
+      // 현재 선택된 카테고리가 필터링된 목록에 없다면 초기화
+      final validIds = keywordTypes.map<int>((e) => e['id'] as int).toSet();
+      if (selectedKeywordTypeId != null &&
+          !validIds.contains(selectedKeywordTypeId)) {
+        selectedKeywordTypeId = null;
+      }
     } catch (e) {
       throw Exception('카테고리를 불러오는 중 오류가 발생했습니다: $e');
     } finally {
@@ -413,7 +421,7 @@ class ItemAddViewModel extends ChangeNotifier {
         builder: (_) => WillPopScope(
           onWillPop: () async => false,
           child: AskPopup(
-            content: '매물 등록 확인 화면으로 이동하여 최종 등록을 진행해 주세요.',
+            content: '매물 등록 확인 화면으로 이동하여\n최종 등록을 진행해 주세요.',
             yesText: '이동하기',
             yesLogic: () async {
               navigator.pop();


### PR DESCRIPTION
1. 카테고리 목록에서 ‘전체’ 제거
	• 매물 등록 화면의 카테고리 드롭다운에서 ‘전체’가 표시되지 않도록 정리했습니다.

2. 경매 기간(시간) 처리 로직 점검 및 수정
	• 신규 등록 플로우에서는 선택한 시간이 분 단위로 정상 전달됨을 확인했습니다.
	• 수정 모드에서는 DB 값이 실제로 분 단위였기 때문에, 이를 시간으로 변환해 UI에 반영하도록 변경했습니다.
	• 240, 720, 1440 등의 분 단위 값이 각각 4·12·24시간으로 올바르게 표시되도록 했습니다.

3. 매물 등록 성공 팝업 문구 줄바꿈 정리
	• AskPopup 문구를 두 줄로 표시하도록 변경했습니다.