### PR TITLE
Feat/ 경매 기간 데이터 연동 및 등록 확인 화면 UI 정비

### DIFF
--- a/lib/features/item/add/data/datasources/supabase_item_add_datasource.dart
+++ b/lib/features/item/add/data/datasources/supabase_item_add_datasource.dart
@@ -130,6 +130,7 @@ class SupabaseItemAddDatasource {
       description: entity.description,
       startPrice: entity.startPrice,
       instantPrice: entity.instantPrice,
+      auctionDurationHours: entity.auctionDurationHours,
       thumbnailUrl: imageUrls[thumbnailIndex],
       keywordTypeId: entity.keywordTypeId,
     );

--- a/lib/features/item/item_registration_detail/screen/item_registration_detail_screen.dart
+++ b/lib/features/item/item_registration_detail/screen/item_registration_detail_screen.dart
@@ -31,6 +31,19 @@ class ItemRegistrationDetailScreen extends StatelessWidget {
         ? _formatPrice(item.instantPrice)
         : null;
 
+    String auctionDurationText;
+    switch (item.auctionDurationHours) {
+      case 12:
+        auctionDurationText = '12시간';
+        break;
+      case 24:
+        auctionDurationText = '24시간';
+        break;
+      default:
+        auctionDurationText = '${item.auctionDurationHours}시간';
+        break;
+    }
+
     return ChangeNotifierProvider<ItemRegistrationDetailViewModel>(
       create: (_) => ItemRegistrationDetailViewModel(item: item)..loadTerms(),
       child: Consumer<ItemRegistrationDetailViewModel>(
@@ -67,9 +80,11 @@ class ItemRegistrationDetailScreen extends StatelessWidget {
                         children: [
                           _buildImageSection(),
                           const SizedBox(height: 16),
-                          _buildInfoCard(startPriceText, instantPriceText),
-                          const SizedBox(height: 12),
-                          _buildDescriptionCard(),
+                          _buildInfoCard(
+                            startPriceText,
+                            instantPriceText,
+                            auctionDurationText,
+                          ),
                         ],
                       ),
                     ),
@@ -119,7 +134,11 @@ class ItemRegistrationDetailScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildInfoCard(String startPriceText, String? instantPriceText) {
+  Widget _buildInfoCard(
+    String startPriceText,
+    String? instantPriceText,
+    String auctionDurationText,
+  ) {
     return Container(
       decoration: BoxDecoration(
         color: Colors.white,
@@ -132,42 +151,64 @@ class ItemRegistrationDetailScreen extends StatelessWidget {
           Text(
             item.title,
             style: const TextStyle(
-              fontSize: 16,
+              fontSize: 17,
               fontWeight: FontWeight.w600,
               color: textColor,
             ),
           ),
-          const SizedBox(height: 8),
-          Text(
-            '시작가 ₩$startPriceText',
-            style: const TextStyle(fontSize: 13, color: textColor),
+          const SizedBox(height: 12),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                '시작가',
+                style: TextStyle(fontSize: 14, color: textColor),
+              ),
+              Text(
+                '$startPriceText원',
+                style: const TextStyle(
+                  fontSize: 14,
+                  color: textColor,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
           ),
           const SizedBox(height: 4),
-          Text(
-            instantPriceText != null
-                ? '즉시 입찰가 ₩$instantPriceText'
-                : '즉시 입찰가: 없음',
-            style: const TextStyle(fontSize: 13, color: iconColor),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                '즉시 입찰가',
+                style: TextStyle(fontSize: 14, color: textColor),
+              ),
+              Text(
+                instantPriceText != null ? '$instantPriceText원' : '없음',
+                style: const TextStyle(fontSize: 14, color: textColor),
+              ),
+            ],
           ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildDescriptionCard() {
-    return Container(
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
+          const SizedBox(height: 4),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                '경매 기간',
+                style: TextStyle(fontSize: 14, color: textColor),
+              ),
+              Text(
+                auctionDurationText,
+                style: const TextStyle(fontSize: 14, color: textColor),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          const Divider(height: 1, thickness: 1, color: Color(0xFFE5E5E5)),
+          const SizedBox(height: 12),
           const Text(
             '상품 설명',
             style: TextStyle(
-              fontSize: 14,
+              fontSize: 15,
               fontWeight: FontWeight.w600,
               color: textColor,
             ),
@@ -175,7 +216,7 @@ class ItemRegistrationDetailScreen extends StatelessWidget {
           const SizedBox(height: 8),
           Text(
             item.description,
-            style: const TextStyle(fontSize: 13, color: textColor),
+            style: const TextStyle(fontSize: 14, color: textColor),
           ),
         ],
       ),

--- a/lib/features/item/item_registration_list/data/datasource/item_registration_list_datasource.dart
+++ b/lib/features/item/item_registration_list/data/datasource/item_registration_list_datasource.dart
@@ -19,7 +19,7 @@ class RegistrationDatasource {
       final List<dynamic> rows = await _supabase
           .from('items_detail')
           .select(
-        'item_id, title, description, start_price, buy_now_price, keyword_type, seller_id, thumbnail_image, is_agreed, created_at',
+        'item_id, title, description, start_price, buy_now_price, keyword_type, seller_id, thumbnail_image, is_agreed, created_at, auction_duration_hours',
       )
           .eq('seller_id', user.id)
           .filter('is_agreed', 'is', null)
@@ -34,6 +34,8 @@ class RegistrationDatasource {
           description: row['description']?.toString() ?? '',
           startPrice: (row['start_price'] as num?)?.toInt() ?? 0,
           instantPrice: (row['buy_now_price'] as num?)?.toInt() ?? 0,
+          auctionDurationHours:
+              (row['auction_duration_hours'] as num?)?.toInt() ?? 0,
           thumbnailUrl: row['thumbnail_image']?.toString(),
           keywordTypeId: (row['keyword_type'] as num?)?.toInt(),
         );

--- a/lib/features/item/item_registration_list/model/item_registration_entity.dart
+++ b/lib/features/item/item_registration_list/model/item_registration_entity.dart
@@ -5,6 +5,7 @@ class ItemRegistrationData {
     required this.description,
     required this.startPrice,
     required this.instantPrice,
+    required this.auctionDurationHours,
     this.thumbnailUrl,
     this.keywordTypeId,
   });
@@ -14,6 +15,7 @@ class ItemRegistrationData {
   final String description;
   final int startPrice;
   final int instantPrice;
+  final int auctionDurationHours;
   final String? thumbnailUrl;
   final int? keywordTypeId;
 }


### PR DESCRIPTION
1. 경매 기간 데이터 추가
	• ItemRegistrationData에 auctionDurationHours 필드를 추가했습니다.
	• RegistrationDatasource에서 auction_duration_hours 컬럼을 조회해 모델에 매핑했습니다.
	
2. 매물 등록 확인 화면 UI 개편
	• ItemRegistrationDetailScreen에서 경매 기간 표시를 item.auctionDurationHours 기반으로 생성하도록 변경했습니다.
	• 정보 구성은 하나의 카드 내부에 제목, 시작가·즉시 입찰가·경매 기간(3줄), 구분선, 상품 설명(제목+내용) 구조로 정리했습니다.
	• 텍스트 스타일을 fontSize 14 / color textColor로 통일하고, 시작가만 굵게 표시했습니다.
	• 즉시 입찰가가 없을 때는 ‘없음’을 검은색으로 노출하도록 수정했습니다.
	• 금액 표기 형식을 “₩” 제거 후 “원” 형태로 통일했습니다.