### PR TITLE
Feat/ 거래내역 라우트 수정 및 상태 라벨 단순화

### DIFF
--- a/lib/features/item/user_history/data/datasource/user_history_data.dart
+++ b/lib/features/item/user_history/data/datasource/user_history_data.dart
@@ -128,30 +128,35 @@ class _StatusInfo {
 }
 
 _StatusInfo _mapAuctionTradeStatus(int? auctionCode, int? tradeCode) {
-  // trade_status_code 우선
-  if (tradeCode == 550) {
-    return _StatusInfo('거래 완료', tradeSaleDoneColor);
-  }
-  if (tradeCode == 520) {
-    return _StatusInfo('구매 완료', tradePurchaseDoneColor);
-  }
-  if (tradeCode == 510) {
-    return _StatusInfo('결제 대기', tradeBidPendingColor);
+  // trade_status_code 기준으로 우선 판단
+  // ● 진행 중으로 볼 상태들 → '판매중'
+  //   - 결제 대기(510) 포함
+  // ● 그 외 완료/종료 코드들 → '거래 종료'
+
+  if (tradeCode != null) {
+    if (tradeCode == 510) {
+      return _StatusInfo('판매중', tradeBidPendingColor);
+    }
+    // 520(구매 완료), 550(거래 완료) 등 기타 trade 종료 상태
+    return _StatusInfo('거래 종료', tradeSaleDoneColor);
   }
 
-  // 그 외에는 auction_status_code 기준
+  // trade_code 가 없을 때는 auction_status_code 로 판단
   switch (auctionCode) {
+    // 경매 대기/진행/즉시구매 진행 중 → 판매중
     case 300: // 경매 대기
     case 310: // 경매 진행 중
     case 311: // 즉시 구매 진행 중
-      return _StatusInfo('입찰 중', tradeBidPendingColor);
+      return _StatusInfo('판매중', tradeBidPendingColor);
+
+    // 낙찰/구매 완료/유찰 등 → 거래 종료
     case 321: // 낙찰
-      return _StatusInfo('판매 완료', tradeSaleDoneColor);
     case 322: // 즉시 구매 완료
-      return _StatusInfo('구매 완료', tradePurchaseDoneColor);
     case 323: // 유찰
-      return _StatusInfo('유찰', tradeBlockedColor);
+      return _StatusInfo('거래 종료', tradeSaleDoneColor);
+
     default:
-      return _StatusInfo('입찰 중', tradeBidPendingColor);
+      // 알 수 없는 상태도 기본적으로 진행 중으로 취급
+      return _StatusInfo('판매중', tradeBidPendingColor);
   }
 }

--- a/lib/features/item/user_profile_history/screen/user_history_screen.dart
+++ b/lib/features/item/user_profile_history/screen/user_history_screen.dart
@@ -1,4 +1,8 @@
+import 'package:bidbird/core/utils/ui_set/border_radius_style.dart';
 import 'package:bidbird/core/utils/ui_set/colors_style.dart';
+import 'package:bidbird/features/item/user_history/data/repository/user_history_repository.dart';
+import 'package:bidbird/features/item/user_history/model/user_history_entity.dart';
+import 'package:bidbird/features/item/widgets/trade_status_chip.dart';
 import 'package:flutter/material.dart';
 
 class UserTradeHistoryScreen extends StatelessWidget {
@@ -9,15 +13,90 @@ class UserTradeHistoryScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('거래내역'),
-        centerTitle: true,
-      ),
+      appBar: AppBar(title: const Text('거래내역'), centerTitle: true),
       backgroundColor: BackgroundColor,
-      body: const Center(
-        child: Text(
-          '거래 내역 화면입니다.',
-          style: TextStyle(fontSize: 14, color: Colors.white),
+      body: SafeArea(
+        child: FutureBuilder<List<UserTradeSummary>>(
+          future: UserProfileRepository().fetchUserTrades(userId),
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            final trades = snapshot.data ?? [];
+            if (trades.isEmpty) {
+              return const Center(
+                child: Text(
+                  '거래 내역이 없습니다.',
+                  style: TextStyle(fontSize: 14, color: Colors.black54),
+                ),
+              );
+            }
+
+            return ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: trades.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 8),
+              itemBuilder: (context, index) {
+                final trade = trades[index];
+                return Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: BackgroundColor,
+                    borderRadius: defaultBorder,
+                  ),
+                  child: Row(
+                    children: [
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: SizedBox(
+                          width: 48,
+                          height: 48,
+                          child: trade.thumbnailUrl != null &&
+                                  trade.thumbnailUrl!.isNotEmpty
+                              ? Image.network(
+                                  trade.thumbnailUrl!,
+                                  fit: BoxFit.cover,
+                                  errorBuilder: (context, error, stackTrace) =>
+                                      Container(color: BackgroundColor),
+                                )
+                              : Container(color: BackgroundColor),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              trade.title,
+                              style: const TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              '${trade.price}  ·  ${trade.date}',
+                              style: const TextStyle(
+                                fontSize: 12,
+                                color: BorderColor,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      TradeStatusChip(
+                        label: trade.statusLabel,
+                        color: trade.statusColor,
+                      ),
+                    ],
+                  ),
+                );
+              },
+            );
+          },
         ),
       ),
     );


### PR DESCRIPTION
1. 거래내역 라우팅 오류 수정
	• 구현 화면으로 교체했습니다.

2. 거래내역 조회 흐름 검증
	• 판매자 기준으로 items_detail → auctions 조인 형태로 거래내역을 조회하는 기존 로직이 정상 동작함을 확인했습니다.

3. 상태 칩 텍스트 단순화
	• 기존의 복잡한 상태 텍스트(입찰 중, 낙찰, 유찰 등)를 모두 제거했습니다.
	• 모든 거래는 판매 중, 거래 종료  두 가지로만 표시되도록 정리했습니다.
	• trade_status_code와 auction_status_code의 모든 분기를 정리해 단일 라벨로 매핑했습니다.
	• 칩 색상도 두 상태에 맞춰 통일했습니다.