### PR TITLE
Feat/ 상세 타이머 실시간 갱신 적용 및 홈·상세 시간 포맷 분리

### DIFF
--- a/lib/features/item/detail/screen/item_detail_utils.dart
+++ b/lib/features/item/detail/screen/item_detail_utils.dart
@@ -1,11 +1,12 @@
 String formatRemainingTime(DateTime finishTime) {
   final diff = finishTime.difference(DateTime.now());
   if (diff.isNegative) {
-    return '00:00';
+    return '00:00:00';
   }
   final hours = diff.inHours;
   final minutes = diff.inMinutes % 60;
-  return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}';
+  final seconds = diff.inSeconds % 60;
+  return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
 }
 
 String formatPrice(int price) {

--- a/lib/features/item/detail/screen/widgets/item_bottom_action_bar.dart
+++ b/lib/features/item/detail/screen/widgets/item_bottom_action_bar.dart
@@ -60,6 +60,7 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
     final isTopBidder = itemDetailViewModel?.isTopBidder ?? false;
     final isMyItem = widget.isMyItem;
     final isBidRestricted = _isBidRestricted;
+    final bool isTimeOver = DateTime.now().isAfter(widget.item.finishTime);
 
     const disabledStatusesForBuyNow = {
       300,
@@ -70,7 +71,8 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
     };
     final bool showBuyNow =
         widget.item.buyNowPrice > 0 &&
-        !disabledStatusesForBuyNow.contains(_statusCode);
+        !disabledStatusesForBuyNow.contains(_statusCode) &&
+        !isTimeOver;
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -178,8 +180,12 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
   Widget _buildBidButton(bool isTopBidder) {
     final int statusCode = _statusCode ?? 0;
 
-    final bool isAuctionEnded =
-        statusCode == 321 || statusCode == 322 || statusCode == 323;
+    final bool isTimeOver = DateTime.now().isAfter(widget.item.finishTime);
+
+    final bool isAuctionEnded = isTimeOver ||
+        statusCode == 321 ||
+        statusCode == 322 ||
+        statusCode == 323;
 
     final bool isAuctionActive = statusCode == 310;
     final bool isBuyNowInProgress = statusCode == 311;
@@ -332,8 +338,11 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
     // 1) 이미 최고 입찰자인 경우
     if (isTopBidder) {
       reason = '최고 입찰자입니다';
+    } else if (isTimeOver) {
+      // 2) 경매 시간이 지난 경우
+      reason = '경매가 종료되었습니다.';
     } else {
-      // 2) 상태 코드별 상세 사유
+      // 3) 상태 코드별 상세 사유
       switch (statusCode) {
         case 300:
           reason = '경매가 아직 시작되지 않았습니다';

--- a/lib/features/item/detail/screen/widgets/item_image_section.dart
+++ b/lib/features/item/detail/screen/widgets/item_image_section.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bidbird/core/utils/ui_set/colors_style.dart';
 import 'package:bidbird/features/item/detail/model/item_detail_entity.dart';
 import 'package:flutter/material.dart';
@@ -16,9 +18,29 @@ class ItemImageSection extends StatefulWidget {
 class _ItemImageSectionState extends State<ItemImageSection> {
   int _currentPage = 0;
   final PageController _pageController = PageController();
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (!mounted) return;
+
+      // 경매 종료 이후에는 타이머 중단
+      if (DateTime.now().isAfter(widget.item.finishTime)) {
+        timer.cancel();
+        setState(() {});
+        return;
+      }
+
+      setState(() {});
+    });
+  }
 
   @override
   void dispose() {
+    _timer?.cancel();
     _pageController.dispose();
     super.dispose();
   }
@@ -81,11 +103,15 @@ class _ItemImageSectionState extends State<ItemImageSection> {
                     vertical: 4,
                   ),
                   decoration: BoxDecoration(
-                    color: RedColor,
+                    color: DateTime.now().isAfter(widget.item.finishTime)
+                        ? Colors.black
+                        : RedColor,
                     borderRadius: BorderRadius.circular(4),
                   ),
                   child: Text(
-                    '${formatRemainingTime(widget.item.finishTime)} 남음',
+                    DateTime.now().isAfter(widget.item.finishTime)
+                        ? '경매 종료'
+                        : '${formatRemainingTime(widget.item.finishTime)} 남음',
                     style: const TextStyle(
                       color: Colors.white,
                       fontSize: 12,


### PR DESCRIPTION
1. 상세 화면 타이머 UI 추가
	• 1초 단위 실시간 타이머를 적용했습니다.
	        - 배지 스타일
	                 • 진행 중: 빨간 배지 + HH:MM:SS 남음
                    	• 종료 후: 검은 배지 + “경매 종료”

2. 상세 화면 하단 버튼 영역 종료 처리
	• finishTime 기준으로 isTimeOver 계산해 버튼 노출 조건에 반영했습니다.
	         • 입찰 버튼 비활성화 → “경매가 종료되었습니다.” 표시
	          • 즉시구매 버튼 숨김
	
4. 시간 포맷 함수 분리
	• 상세: item_detail_utils.dart → HH:MM:SS 전용