### PR TITLE
Feat/ 낙찰 화면 모듈 분리 및 상세 진입 플로우 연동

### DIFF
--- a/lib/features/item/detail/screen/item_detail_screen.dart
+++ b/lib/features/item/detail/screen/item_detail_screen.dart
@@ -4,6 +4,8 @@ import 'package:bidbird/features/item/detail/viewmodel/item_detail_viewmodel.dar
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../item_bid_win/model/item_bid_win_entity.dart';
+import '../../item_bid_win/screen/item_bid_win_screen.dart';
 import '../../../report/ui/report_screen.dart';
 import 'widgets/item_image_section.dart';
 import 'widgets/item_main_info_section.dart';
@@ -26,8 +28,15 @@ class ItemDetailScreen extends StatelessWidget {
   }
 }
 
-class _ItemDetailScaffold extends StatelessWidget {
+class _ItemDetailScaffold extends StatefulWidget {
   const _ItemDetailScaffold();
+
+  @override
+  State<_ItemDetailScaffold> createState() => _ItemDetailScaffoldState();
+}
+
+class _ItemDetailScaffoldState extends State<_ItemDetailScaffold> {
+  bool _hasPushedBidWin = false;
 
   @override
   Widget build(BuildContext context) {
@@ -61,6 +70,25 @@ class _ItemDetailScaffold extends StatelessWidget {
         final currentUser = supabase.auth.currentUser;
         final bool isMyItem =
             currentUser != null && currentUser.id == item.sellerId;
+
+        // 낙찰된 매물이고, 내가 낙찰자인 경우: 상세 진입 시 한 번만 낙찰 화면을 위에 띄움
+        final bool isAuctionWonByMe =
+            item.statusCode == 321 && (vm.isTopBidder == true);
+
+        if (isAuctionWonByMe && !_hasPushedBidWin) {
+          _hasPushedBidWin = true;
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            final bidWinEntity = ItemBidWinEntity.fromItemDetail(item);
+            Navigator.of(context).push(
+              PageRouteBuilder(
+                pageBuilder: (_, __, ___) => ItemBidSuccessScreen(item: bidWinEntity),
+                transitionDuration: Duration.zero,
+                reverseTransitionDuration: Duration.zero,
+              ),
+            );
+          });
+        }
 
         return Scaffold(
           backgroundColor: Colors.white,

--- a/lib/features/item/detail/screen/widgets/item_bottom_action_bar.dart
+++ b/lib/features/item/detail/screen/widgets/item_bottom_action_bar.dart
@@ -3,12 +3,14 @@ import 'package:bidbird/core/utils/ui_set/colors_style.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../../bottom_sheet_buy_now_input/model/check_bid_restriction_usecase.dart';
 import '../../../bottom_sheet_buy_now_input/data/repository/bid_restriction_gateway_impl.dart';
+import '../../../bottom_sheet_buy_now_input/model/check_bid_restriction_usecase.dart';
 import '../../../bottom_sheet_buy_now_input/screen/bottom_sheet_buy_now_input.dart';
 import '../../../bottom_sheet_buy_now_input/viewmodel/buy_now_input_viewmodel.dart';
 import '../../../bottom_sheet_price_Input/screen/price_input_screen.dart';
 import '../../../bottom_sheet_price_Input/viewmodel/price_input_viewmodel.dart';
+import '../../../item_bid_win/model/item_bid_win_entity.dart';
+import '../../../item_bid_win/screen/item_bid_win_screen.dart';
 import '../../model/item_detail_entity.dart';
 import '../../viewmodel/item_detail_viewmodel.dart';
 
@@ -197,7 +199,8 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
         !isTopBidder &&
         !isBuyNowInProgress;
 
-    if (isAuctionEnded) {
+    // 경매가 완전히 끝난 상태(유찰/즉시구매 완료 등)
+    if (isAuctionEnded && statusCode != 321) {
       return Container(
         height: 40,
         padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -214,6 +217,37 @@ class _ItemBottomActionBarState extends State<ItemBottomActionBar> {
               fontWeight: FontWeight.w600,
               color: TopBidderTextColor,
             ),
+          ),
+        ),
+      );
+    }
+
+    // 경매 낙찰(321) 상태에서, 내가 낙찰자인 경우 결제 버튼 노출
+    // 현재 화면의 ViewModel 에서 isTopBidder 가 true 인 상태를 낙찰자로 간주
+    if (statusCode == 321 && isTopBidder) {
+      final bidWinEntity = ItemBidWinEntity.fromItemDetail(widget.item);
+
+      return ElevatedButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => ItemBidSuccessScreen(item: bidWinEntity),
+            ),
+          );
+        },
+        style: ElevatedButton.styleFrom(
+          backgroundColor: blueColor,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8.7),
+          ),
+        ),
+        child: const Text(
+          '결제하러 가기',
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
           ),
         ),
       );

--- a/lib/features/item/item_bid_win/data/datasource/item_bid_win_datasource.dart
+++ b/lib/features/item/item_bid_win/data/datasource/item_bid_win_datasource.dart
@@ -1,0 +1,9 @@
+import 'package:bidbird/features/item/detail/model/item_detail_entity.dart';
+
+import '../../model/item_bid_win_entity.dart';
+
+class ItemBidWinDatasource {
+  ItemBidWinEntity toEntityFromDetail(ItemDetail item) {
+    return ItemBidWinEntity.fromItemDetail(item);
+  }
+}

--- a/lib/features/item/item_bid_win/data/repository/item_bid_win_repository.dart
+++ b/lib/features/item/item_bid_win/data/repository/item_bid_win_repository.dart
@@ -1,0 +1,15 @@
+import 'package:bidbird/features/item/detail/model/item_detail_entity.dart';
+
+import '../../model/item_bid_win_entity.dart';
+import '../datasource/item_bid_win_datasource.dart';
+
+class ItemBidWinRepository {
+  ItemBidWinRepository({ItemBidWinDatasource? datasource})
+      : _datasource = datasource ?? ItemBidWinDatasource();
+
+  final ItemBidWinDatasource _datasource;
+
+  ItemBidWinEntity fromItemDetail(ItemDetail item) {
+    return _datasource.toEntityFromDetail(item);
+  }
+}

--- a/lib/features/item/item_bid_win/model/item_bid_win_entity.dart
+++ b/lib/features/item/item_bid_win/model/item_bid_win_entity.dart
@@ -1,0 +1,24 @@
+import 'package:bidbird/features/item/detail/model/item_detail_entity.dart';
+
+class ItemBidWinEntity {
+  ItemBidWinEntity({
+    required this.itemId,
+    required this.title,
+    required this.images,
+    required this.winPrice,
+  });
+
+  final String itemId;
+  final String title;
+  final List<String> images;
+  final int winPrice;
+
+  factory ItemBidWinEntity.fromItemDetail(ItemDetail item) {
+    return ItemBidWinEntity(
+      itemId: item.itemId,
+      title: item.itemTitle,
+      images: item.itemImages,
+      winPrice: item.currentPrice,
+    );
+  }
+}

--- a/lib/features/item/item_bid_win/screen/item_bid_win_screen.dart
+++ b/lib/features/item/item_bid_win/screen/item_bid_win_screen.dart
@@ -1,0 +1,193 @@
+import 'package:bidbird/core/utils/ui_set/border_radius_style.dart';
+import 'package:bidbird/core/utils/ui_set/colors_style.dart';
+import 'package:bidbird/features/chat/screen/chatting_room_screen.dart';
+import 'package:flutter/material.dart';
+
+import '../model/item_bid_win_entity.dart';
+
+class ItemBidSuccessScreen extends StatelessWidget {
+  const ItemBidSuccessScreen({super.key, required this.item});
+
+  final ItemBidWinEntity item;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: BackgroundColor,
+      body: SafeArea(
+        child: Column(
+          children: [
+            Align(
+              alignment: Alignment.centerRight,
+              child: IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: () => Navigator.pop(context),
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Icon(
+              Icons.check_circle,
+              size: 72,
+              color: blueColor,
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              '낙찰 되었습니다!',
+              style: TextStyle(
+                fontSize: 22,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              '축하합니다! 낙찰되셨습니다.',
+              style: TextStyle(
+                fontSize: 13,
+                color: iconColor,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: defaultBorder,
+                  boxShadow: const [
+                    BoxShadow(
+                      color: shadowHigh,
+                      offset: Offset(0, 4),
+                      blurRadius: 12,
+                    ),
+                  ],
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    AspectRatio(
+                      aspectRatio: 1,
+                      child: Container(
+                        decoration: const BoxDecoration(
+                          color: ImageBackgroundColor,
+                          borderRadius: BorderRadius.only(
+                            topLeft: Radius.circular(defaultRadius),
+                            topRight: Radius.circular(defaultRadius),
+                          ),
+                        ),
+                        clipBehavior: Clip.hardEdge,
+                        child: item.images.isNotEmpty
+                            ? Image.network(
+                                item.images.first,
+                                fit: BoxFit.cover,
+                              )
+                            : const Center(
+                                child: Text(
+                                  '상품 이미지',
+                                  style: TextStyle(color: iconColor),
+                                ),
+                              ),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            item.title,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(height: 6),
+                          const Text(
+                            '낙찰가',
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: iconColor,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            '${item.winPrice}원',
+                            style: const TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.w800,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const Spacer(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+              child: Column(
+                children: [
+                  SizedBox(
+                    width: double.infinity,
+                    height: 48,
+                    child: ElevatedButton(
+                      onPressed: () {
+                        // TODO: 결제 플로우 연동
+                      },
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: blueColor,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: defaultBorder,
+                        ),
+                      ),
+                      child: const Text(
+                        '결제하기',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w700,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  SizedBox(
+                    width: double.infinity,
+                    height: 48,
+                    child: OutlinedButton(
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => ChattingRoomScreen(itemId: item.itemId),
+                          ),
+                        );
+                      },
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: textColor,
+                        side: const BorderSide(color: BorderColor),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: defaultBorder,
+                        ),
+                      ),
+                      child: const Text(
+                        '판매자에게 채팅하기',
+                        style: TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/item/item_bid_win/viewmodel/item_bid_win_viewmodel.dart
+++ b/lib/features/item/item_bid_win/viewmodel/item_bid_win_viewmodel.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/foundation.dart';
+
+import '../data/repository/item_bid_win_repository.dart';
+import '../model/item_bid_win_entity.dart';
+import '../../detail/model/item_detail_entity.dart';
+
+class ItemBidWinViewModel extends ChangeNotifier {
+  ItemBidWinViewModel({ItemBidWinRepository? repository})
+      : _repository = repository ?? ItemBidWinRepository();
+
+  final ItemBidWinRepository _repository;
+
+  ItemBidWinEntity? _item;
+  ItemBidWinEntity? get item => _item;
+
+  bool _isPaying = false;
+  bool get isPaying => _isPaying;
+
+  String? _error;
+  String? get error => _error;
+
+  void initWithDetail(ItemDetail detail) {
+    _item = _repository.fromItemDetail(detail);
+    notifyListeners();
+  }
+
+  Future<void> startPayment() async {
+    if (_item == null || _isPaying) return;
+    _isPaying = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      // TODO: 결제 API 연동 및 상태 업데이트
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+    } catch (e) {
+      _error = e.toString();
+    } finally {
+      _isPaying = false;
+      notifyListeners();
+    }
+  }
+}


### PR DESCRIPTION
1. 낙찰 화면 모듈 구조화
	• item_bid_win 모듈을 model–datasource–repository–viewmodel–screen 구조로 정리했습니다.
	
2. 낙찰 화면 UI 구성
	• ItemBidSuccessScreen을 구현해 낙찰 안내 문구·상품 이미지·낙찰가·하단 버튼 UI를 정리했습니다.
	• 버튼 구성
	      - 파란색 결제하기
	      - 판매자에게 채팅하기 → ChattingRoomScreen(itemId) 이동
	      - UI 요소는 core 색상·곡률 상수 기반으로 통일했습니다.

3. 상세 화면에서 낙찰 진입 플로우 구현
	•	ItemDetailScreen을 StatefulWidget으로 변경해 낙찰 화면 자동 호출 플래그를 추가했습니다.
	•	상세 로드 이후 상태 코드 321 + 내가 낙찰자인 경우 자동으로 낙찰 화면을 띄우도록 구성했습니다.

4. 채팅 연결 구현
	• 판매자에게 채팅하기 버튼은 ChattingRoomScreen(itemId)를 호출하도록 구성했습니다.
	• 채팅방이 이미 존재하면 해당 방에 입장하고, 없으면 첫 메시지 전송 시 자동 생성되는 구조와 연동됩니다.

5. 기타 개선
	•모듈 내에 ItemBidWinViewModel을 추가해 추후 결제 플로우 확장에 대비한 구조를 마련했습니다.
