### PR TITLE
feat/상세·홈·하단바 정리 및 본인인증 로직 안정화

### DIFF
--- a/lib/features/item/detail/screen/item_detail_screen.dart
+++ b/lib/features/item/detail/screen/item_detail_screen.dart
@@ -4,8 +4,6 @@ import 'package:bidbird/features/item/detail/viewmodel/item_detail_viewmodel.dar
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../item_bid_win/model/item_bid_win_entity.dart';
-import '../../item_bid_win/screen/item_bid_win_screen.dart';
 import '../../../report/ui/report_screen.dart';
 import 'widgets/item_image_section.dart';
 import 'widgets/item_main_info_section.dart';
@@ -36,8 +34,6 @@ class _ItemDetailScaffold extends StatefulWidget {
 }
 
 class _ItemDetailScaffoldState extends State<_ItemDetailScaffold> {
-  bool _hasPushedBidWin = false;
-
   @override
   Widget build(BuildContext context) {
     return Consumer<ItemDetailViewModel>(


### PR DESCRIPTION
• 상세 화면(item_detail_screen)에서 사용되지 않는 import와 미사용 필드 제거
• 홈 화면(home_screen) Material 3 권장 API 기준으로 SearchBar 및 FAB 인증 가드 정리