### PR TITLE
Refactor/채팅 화면 ui 고도화 7차

### DIFF
--- a/lib/features/chat/data/repositories/chat_repositorie.dart
+++ b/lib/features/chat/data/repositories/chat_repositorie.dart
@@ -19,6 +19,21 @@ class ChatRepositorie {
     return await _chatDatasource.getMessages(chattingRoomId);
   }
 
+  Future<List<ChatMessageEntity>> getOlderMessages(
+    String chattingRoomId,
+    String beforeCreatedAtIso, {
+    int limit = 50,
+  }) async {
+    print(
+      "리포지토리에서 이전 메세지 fetch, beforeCreatedAt = $beforeCreatedAtIso",
+    );
+    return await _chatDatasource.getOlderMessages(
+      roomId: chattingRoomId,
+      beforeCreatedAtIso: beforeCreatedAtIso,
+      limit: limit,
+    );
+  }
+
   Future<String?> getRoomId(String itemId) async {
     return await _chatDatasource.getRoomId(itemId);
   }


### PR DESCRIPTION
1. 채팅 이미지 로딩 개선
	• 이미지 크기 계산용 로딩 코드를 제거해 이중 로딩 문제를 없앴습니다.
	• 한 번의 CachedNetworkImage만 사용하도록 구조를 단순화했습니다.
	• 로딩 중 인디케이터와 실패 아이콘을 추가했습니다.
	• 이미지 URL은 서버에서 이미 리사이즈되어 온다는 전제로 그대로 사용했습니다.

2. 채팅방 상단 썸네일 처리 개선
	• thumbnailImage를 널 허용으로 변경해 파싱 오류를 방지했습니다.
	• 값이 없을 때는 썸네일 영역을 렌더하지 않도록 수정했습니다.

3. 메시지 최초 로딩 최적화
	• 입장 시 최신 50개 메시지만 불러오도록 쿼리를 제한했습니다.
	• 반환 시 예전→최신 순으로 정렬을 유지했습니다.
	• 메시지가 50개 미만이면 더 불러올 메시지가 없다고 판단하도록 처리했습니다.

4. 이전 메시지 페이지네이션 추가
	• Supabase RPC를 추가해 특정 시점 이전 메시지를 조회할 수 있게 만들었습니다.
	• ViewModel에서 스크롤 상단 접근 시 이전 메시지를 불러오도록 연결했습니다.
	• 중복 요청 방지용 플래그(isLoadingMore, hasMore)를 추가했습니다.
	• 가장 오래된 메시지의 created_at을 기준으로 이전 메시지를 계속 불러오는 구조로 완성했습니다.