### PR TITLE
Redesign/현재 거래내역 UI 개선 및 핵심 업무 집중 표시

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -168,18 +168,45 @@ GoRouter createAppRouter(BuildContext context) {
                   final extra = state.extra;
                   if (extra is Map<String, dynamic>) {
                     final actionType = extra['actionType'] as TradeActionType;
-                    final isSeller = extra['isSeller'] as bool;
-                    return NoTransitionPage(
-                      child: ChangeNotifierProvider<CurrentTradeViewModel>(
-                        create: (_) => CurrentTradeViewModel(
-                          repository: CurrentTradeRepositoryImpl(),
-                        )..loadData(),
-                        child: FilteredTradeListScreen(
-                          actionType: actionType,
-                          isSeller: isSeller,
+                    final isSeller = extra['isSeller'] as bool?;
+                    final actionTypes = extra['actionTypes'] as List<TradeActionType>?;
+                    
+                    // 부모 경로의 ViewModel 찾기
+                    CurrentTradeViewModel? parentViewModel;
+                    try {
+                      // Navigator를 통해 부모 위젯 트리에서 Provider 찾기
+                      final navigatorContext = Navigator.of(context, rootNavigator: false).context;
+                      parentViewModel = Provider.of<CurrentTradeViewModel>(navigatorContext, listen: false);
+                    } catch (e) {
+                      // Provider를 찾을 수 없으면 null
+                    }
+                    
+                    // 기존 ViewModel이 있으면 재사용, 없으면 새로 생성
+                    if (parentViewModel != null) {
+                      return NoTransitionPage(
+                        child: ChangeNotifierProvider<CurrentTradeViewModel>.value(
+                          value: parentViewModel,
+                          child: FilteredTradeListScreen(
+                            actionType: actionType,
+                            isSeller: isSeller,
+                            actionTypes: actionTypes,
+                          ),
                         ),
-                      ),
-                    );
+                      );
+                    } else {
+                      return NoTransitionPage(
+                        child: ChangeNotifierProvider<CurrentTradeViewModel>(
+                          create: (_) => CurrentTradeViewModel(
+                            repository: CurrentTradeRepositoryImpl(),
+                          )..loadData(),
+                          child: FilteredTradeListScreen(
+                            actionType: actionType,
+                            isSeller: isSeller,
+                            actionTypes: actionTypes,
+                          ),
+                        ),
+                      );
+                    }
                   }
                   return const NoTransitionPage(child: CurrentTradeScreen());
                 },

--- a/lib/core/utils/ui_set/colors_style.dart
+++ b/lib/core/utils/ui_set/colors_style.dart
@@ -32,4 +32,15 @@ const Color chatPlusIconColor = Color(0xff5A86F2); // 플러스 버튼 아이콘
 const Color chatBackgroundColor = Color(0xffF7F8FA); // 채팅 화면 전체 배경
 const Color chatTimeTextColor = Color(0xff9CA3AF); // 시간 텍스트 색상
 const Color chatItemSectionBackground = Color(0xffF2F3F5); // 매물 정보 섹션 배경
-const Color chatItemCardBackground = Color(0xffFFFFFF); // 매물 정보 카드 배경/Users/kimjaehyun/Desktop/BidBird/lib/features/chat/presentation
+const Color chatItemCardBackground = Color(0xffFFFFFF); // 매물 정보 카드 배경
+
+// 역할 구분 색상 (구매/판매)
+// 구매 (Buyer)
+const Color rolePurchasePrimary = Color(0xFF3B6EF6); // Primary: #3B6EF6
+const Color rolePurchaseSub = Color(0xFFE8EEFF); // Sub(연한 톤): #E8EEFF
+const Color rolePurchaseText = Color(0xFF1F3FB8); // 텍스트/아이콘 대비용: #1F3FB8
+
+// 판매 (Seller)
+const Color roleSalePrimary = Color(0xFF2FAE8E); // Primary: #2FAE8E
+const Color roleSaleSub = Color(0xFFE6F6F1); // Sub(연한 톤): #E6F6F1
+const Color roleSaleText = Color(0xFF1E7F68); // 텍스트/아이콘 대비용: #1E7F68

--- a/lib/features/item/current_trade/screen/current_trade_screen.dart
+++ b/lib/features/item/current_trade/screen/current_trade_screen.dart
@@ -1,7 +1,10 @@
+import 'package:bidbird/core/managers/item_image_cache_manager.dart';
+import 'package:bidbird/core/utils/item/item_media_utils.dart';
 import 'package:bidbird/core/utils/item/item_trade_status_utils.dart';
 import 'package:bidbird/core/utils/ui_set/colors_style.dart';
 import 'package:bidbird/core/utils/ui_set/fonts_style.dart';
 import 'package:bidbird/core/widgets/notification_button.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -18,11 +21,18 @@ class CurrentTradeScreen extends StatefulWidget {
 }
 
 class _CurrentTradeScreenState extends State<CurrentTradeScreen> {
-  int _selectedTabIndex = 0;
-
   @override
   void initState() {
     super.initState();
+    // 데이터 로드가 안 되어 있으면 로드
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final viewModel = context.read<CurrentTradeViewModel>();
+      if (viewModel.bidHistory.isEmpty && 
+          viewModel.saleHistory.isEmpty && 
+          !viewModel.isLoading) {
+        viewModel.loadData();
+      }
+    });
   }
 
   @override
@@ -39,143 +49,88 @@ class _CurrentTradeScreenState extends State<CurrentTradeScreen> {
       body: SafeArea(
         child: Column(
           children: [
-            // Layer 1: 역할 탭
-            _buildTabBar(),
             // Layer 2: 액션 허브
             if (!viewModel.isLoading && viewModel.error == null) ...[
               const SizedBox(height: 16),
-              if (_selectedTabIndex == 0) ...[
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: _ActionHub(
-                    items: viewModel.saleActionHubItems,
-                    isSeller: true,
-                  ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: _ActionHub(
+                  saleItems: viewModel.saleActionHubItems,
+                  bidItems: viewModel.bidActionHubItems,
+                  todoSaleItems: viewModel.todoSaleItems,
+                  todoBidItems: viewModel.todoBidItems,
+                  saleHistory: viewModel.saleHistory,
+                  bidHistory: viewModel.bidHistory,
                 ),
-                const SizedBox(height: 16),
-              ] else if (_selectedTabIndex == 1) ...[
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: _ActionHub(
-                    items: viewModel.bidActionHubItems,
-                    isSeller: false,
-                  ),
-                ),
-                const SizedBox(height: 16),
-              ],
-            ],
-            // Layer 3: 그룹핑된 리스트
-            if (viewModel.isLoading)
-              const Expanded(child: Center(child: CircularProgressIndicator()))
-            else if (viewModel.error != null)
-              Expanded(
-                child: Center(child: Text(viewModel.error ?? '오류가 발생했습니다.')),
-              )
-            else
-              Expanded(
-                child: _selectedTabIndex == 0
-                    ? _buildSaleHistoryList(viewModel)
-                    : _buildBidHistoryList(viewModel),
               ),
+              const SizedBox(height: 16),
+            ] else ...[
+              const SizedBox.shrink(),
+            ],
+            // Layer 3: 통합된 리스트
+            Expanded(
+              child: _buildContent(viewModel),
+            ),
           ],
         ),
       ),
     );
   }
 
-  Widget _buildTabBar() {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Row(
-        children: [
-          _buildTabButton(index: 0, label: '판매 내역'),
-          const SizedBox(width: 8),
-          _buildTabButton(index: 1, label: '입찰 내역'),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildTabButton({required int index, required String label}) {
-    final bool isSelected = _selectedTabIndex == index;
-
-    return Expanded(
-      child: GestureDetector(
-        onTap: () {
-          setState(() {
-            _selectedTabIndex = index;
-          });
-        },
-        child: Container(
-          height: 40,
-          alignment: Alignment.center,
-          decoration: BoxDecoration(
-            color: isSelected ? blueColor : BackgroundColor,
-            borderRadius: BorderRadius.circular(defaultRadius),
-            border: Border.all(color: blueColor),
-          ),
-          child: Text(
-            label,
-            style: TextStyle(
-              fontSize: buttonFontStyle.fontSize,
-              fontWeight: buttonFontStyle.fontWeight,
-              color: isSelected ? BackgroundColor : blueColor,
+  Widget _buildContent(CurrentTradeViewModel viewModel) {
+    if (viewModel.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    
+    if (viewModel.error != null) {
+      return RefreshIndicator(
+        onRefresh: () => context.read<CurrentTradeViewModel>().refresh(),
+        child: SingleChildScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          child: SizedBox(
+            height: MediaQuery.of(context).size.height - 200,
+            child: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    viewModel.error ?? '오류가 발생했습니다.',
+                    style: const TextStyle(color: Colors.red),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => context.read<CurrentTradeViewModel>().refresh(),
+                    child: const Text('다시 시도'),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
-      ),
-    );
-  }
-
-  Widget _buildBidHistoryList(CurrentTradeViewModel viewModel) {
-    // 모든 거래 항목을 하나의 리스트로 합치기 (완료 제외)
-    final allItems = [
-      ...viewModel.todoBidItems,
-      ...viewModel.inProgressBidItems,
-      ...viewModel.completedBidItems,
-    ];
-
-    if (allItems.isEmpty) {
-      return RefreshIndicator(
-        onRefresh: () => context.read<CurrentTradeViewModel>().refresh(),
-        child: const Center(child: Text('입찰 내역이 없습니다.')),
       );
     }
-
-    return RefreshIndicator(
-      onRefresh: () => context.read<CurrentTradeViewModel>().refresh(),
-      child: ListView(
-        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-        children: [
-          ...allItems.map((item) => Padding(
-                padding: const EdgeInsets.only(bottom: 12),
-                child: _HistoryCard(
-                  title: item.title,
-                  thumbnailUrl: item.thumbnailUrl,
-                  status: item.status,
-                  price: item.price,
-                  itemId: item.itemId,
-                  actionType: item.actionType,
-                  isHighlighted: item.itemStatus == TradeItemStatus.todo,
-                ),
-              )),
-        ],
-      ),
-    );
+    
+    return _buildUnifiedHistoryList(viewModel);
   }
 
-  Widget _buildSaleHistoryList(CurrentTradeViewModel viewModel) {
-    // 모든 거래 항목을 하나의 리스트로 합치기 (완료 포함)
-    final allItems = [
+  Widget _buildUnifiedHistoryList(CurrentTradeViewModel viewModel) {
+    // 판매와 입찰 내역을 모두 합치기
+    final allSaleItems = [
       ...viewModel.todoSaleItems,
       ...viewModel.inProgressSaleItems,
       ...viewModel.completedSaleItems,
-    ];
+    ].where((item) => !item.status.contains('유찰')).toList();
+    
+    final allBidItems = [
+      ...viewModel.todoBidItems,
+      ...viewModel.inProgressBidItems,
+      ...viewModel.completedBidItems,
+    ].where((item) => !item.status.contains('유찰')).toList();
 
-    if (allItems.isEmpty) {
+    if (allSaleItems.isEmpty && allBidItems.isEmpty) {
       return RefreshIndicator(
         onRefresh: () => context.read<CurrentTradeViewModel>().refresh(),
-        child: const Center(child: Text('판매 내역이 없습니다.')),
+        child: const Center(child: Text('거래 내역이 없습니다.')),
       );
     }
 
@@ -184,7 +139,8 @@ class _CurrentTradeScreenState extends State<CurrentTradeScreen> {
       child: ListView(
         padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
         children: [
-          ...allItems.map((item) => Padding(
+          // 판매 내역
+          ...allSaleItems.map((item) => Padding(
                 padding: const EdgeInsets.only(bottom: 12),
                 child: _HistoryCard(
                   title: item.title,
@@ -195,8 +151,43 @@ class _CurrentTradeScreenState extends State<CurrentTradeScreen> {
                   actionType: item.actionType,
                   isHighlighted: item.itemStatus == TradeItemStatus.todo,
                   date: item.date,
+                  isSeller: true,
                 ),
               )),
+          // 입찰 내역
+          ...allBidItems.map((item) => Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: _HistoryCard(
+                  title: item.title,
+                  thumbnailUrl: item.thumbnailUrl,
+                  status: item.status,
+                  price: item.price,
+                  itemId: item.itemId,
+                  actionType: item.actionType,
+                  isHighlighted: item.itemStatus == TradeItemStatus.todo,
+                  isSeller: false,
+                ),
+              )),
+          // 전체 보기 링크
+          Padding(
+            padding: const EdgeInsets.only(top: 8, bottom: 24),
+            child: Center(
+              child: GestureDetector(
+                onTap: () {
+                  context.push('/mypage/trade');
+                },
+                child: Text(
+                  '전체 보기',
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: textColor,
+                    decoration: TextDecoration.underline,
+                    decorationColor: textColor,
+                  ),
+                ),
+              ),
+            ),
+          ),
         ],
       ),
     );
@@ -206,97 +197,165 @@ class _CurrentTradeScreenState extends State<CurrentTradeScreen> {
 /// 액션 허브 위젯 (Layer 2)
 class _ActionHub extends StatelessWidget {
   const _ActionHub({
-    required this.items,
-    required this.isSeller,
+    required this.saleItems,
+    required this.bidItems,
+    required this.todoSaleItems,
+    required this.todoBidItems,
+    required this.saleHistory,
+    required this.bidHistory,
   });
 
-  final List<ActionHubItem> items;
-  final bool isSeller;
+  final List<ActionHubItem> saleItems;
+  final List<ActionHubItem> bidItems;
+  final List<dynamic> todoSaleItems;
+  final List<dynamic> todoBidItems;
+  final List<dynamic> saleHistory;
+  final List<dynamic> bidHistory;
 
   @override
   Widget build(BuildContext context) {
-    final itemList = items.take(2).toList();
+    // 판매와 입찰 액션을 합치고 중복 제거
+    final Map<TradeActionType, int> combinedCounts = {};
+    
+    // 판매 내역 확인
+    for (final item in saleHistory) {
+      TradeActionType? actionType;
+      
+      // tradeStatusCode를 직접 확인
+      if (item.tradeStatusCode == 510) {
+        actionType = TradeActionType.paymentRequired;
+      } else if (item.tradeStatusCode == 520 && !item.hasShippingInfo) {
+        actionType = TradeActionType.shippingInfoRequired;
+      }
+      
+      if (actionType != null) {
+        final beforeCount = combinedCounts[actionType] ?? 0;
+        combinedCounts[actionType] = beforeCount + 1;
+      }
+    }
+    
+    // 입찰 내역 확인
+    for (final item in bidHistory) {
+      TradeActionType? actionType;
+      
+      // tradeStatusCode를 직접 확인
+      if (item.tradeStatusCode == 510) {
+        actionType = TradeActionType.paymentRequired;
+      } else if (item.tradeStatusCode == 520) {
+        // 입찰 내역: 520이면 구매 확정 가능 (배송 정보 있으면 확정, 없으면 대기)
+        if (item.hasShippingInfo) {
+          actionType = TradeActionType.purchaseConfirmRequired;
+        }
+      } else if ((item.tradeStatusCode == null || item.tradeStatusCode == 0) && 
+                 item.auctionStatusCode == 321) {
+        // 입찰 낙찰 상태이고 trade_status_code가 없으면 결제 대기로 간주
+        actionType = TradeActionType.paymentRequired;
+      }
+      
+      if (actionType != null) {
+        final beforeCount = combinedCounts[actionType] ?? 0;
+        combinedCounts[actionType] = beforeCount + 1;
+      }
+    }
+    
+    final combinedItems = combinedCounts.entries
+        .where((e) => e.value > 0) // 0건인 항목은 제외
+        .map((e) => ActionHubItem(actionType: e.key, count: e.value))
+        .toList();
+    
+    combinedItems.sort((a, b) => b.count.compareTo(a.count));
+    
+    // 전체 건수 계산 (0건이어도 표시)
+    final totalCount = combinedItems.fold<int>(0, (sum, item) => sum + item.count);
+    
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        for (int i = 0; i < itemList.length; i++) ...[
-          _ActionHubCard(
-            item: itemList[i],
-            isSeller: isSeller,
-          ),
-          if (i < itemList.length - 1) const SizedBox(height: 16),
-        ],
-      ],
-    );
-  }
-}
-
-class _ActionHubCard extends StatelessWidget {
-  const _ActionHubCard({
-    required this.item,
-    required this.isSeller,
-  });
-
-  final ActionHubItem item;
-  final bool isSeller;
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        context.push(
-          '/bid/filtered',
-          extra: {
-            'actionType': item.actionType,
-            'isSeller': isSeller,
+        // 통합 액션 박스
+        GestureDetector(
+          onTap: () {
+            // 모든 처리해야 할 거래를 보여주는 화면으로 이동
+            if (combinedItems.isNotEmpty) {
+              final actionTypes = combinedItems.map((item) => item.actionType).toList();
+              context.push(
+                '/bid/filtered',
+                extra: {
+                  'actionType': combinedItems.first.actionType, // 호환성을 위해 첫 번째 것도 전달
+                  'actionTypes': actionTypes, // 모든 액션 타입 전달
+                  'isSeller': null, // 판매와 입찰 모두 표시
+                },
+              );
+            }
           },
-        );
-      },
-      child: Container(
-        padding: const EdgeInsets.all(12),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: defaultBorder,
-          border: Border.all(color: BorderColor.withValues(alpha: 0.25)),
-        ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(
-              item.label,
-              style: const TextStyle(
-                fontSize: 14,
-                fontWeight: FontWeight.w600,
-              ),
+          child: Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: blueColor,
+              borderRadius: defaultBorder,
             ),
-            Row(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                  decoration: BoxDecoration(
-                    color: blueColor.withValues(alpha: 0.1),
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Text(
-                    '${item.count}건',
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w600,
-                      color: blueColor,
-                    ),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '지금 처리해야 할 거래 $totalCount건',
+                        style: const TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                          color: Colors.white,
+                        ),
+                      ),
+                      if (combinedItems.isNotEmpty) ...[
+                        const SizedBox(height: 4),
+                        // 액션 타입들을 한 줄로 표시
+                        Wrap(
+                          spacing: 8,
+                          runSpacing: 4,
+                          children: combinedItems.map((item) {
+                            return Text(
+                              '${item.label} ${item.count}건',
+                              style: TextStyle(
+                                fontSize: 13,
+                                color: Colors.white.withValues(alpha: 0.9),
+                              ),
+                            );
+                          }).toList(),
+                        ),
+                      ] else ...[
+                        const SizedBox(height: 4),
+                        Text(
+                          '처리할 거래가 없습니다',
+                          style: TextStyle(
+                            fontSize: 13,
+                            color: Colors.white.withValues(alpha: 0.7),
+                          ),
+                        ),
+                      ],
+                    ],
                   ),
                 ),
-                const SizedBox(width: 4),
-                Icon(
-                  Icons.chevron_right,
-                  size: 20,
-                  color: BorderColor,
+                const SizedBox(width: 12),
+                Container(
+                  width: 40,
+                  height: 40,
+                  decoration: BoxDecoration(
+                    color: Colors.white.withValues(alpha: 0.2),
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(
+                    Icons.chevron_right,
+                    color: Colors.white,
+                    size: 24,
+                  ),
                 ),
               ],
             ),
-          ],
+          ),
         ),
-      ),
+      ],
     );
   }
 }
@@ -311,6 +370,7 @@ class _HistoryCard extends StatelessWidget {
     required this.actionType,
     this.isHighlighted = false,
     this.date,
+    this.isSeller = false, // 판매/입찰 구분용
   });
 
   final String title;
@@ -321,9 +381,16 @@ class _HistoryCard extends StatelessWidget {
   final TradeActionType actionType;
   final bool isHighlighted;
   final String? date;
+  final bool isSeller;
 
   @override
   Widget build(BuildContext context) {
+    // 역할 색상 결정
+    final roleColor = isSeller ? roleSalePrimary : rolePurchasePrimary;
+    final roleSubColor = isSeller ? roleSaleSub : rolePurchaseSub;
+    final roleTextColor = isSeller ? roleSaleText : rolePurchaseText;
+    final roleLabel = isSeller ? '판매' : '구매';
+
     return GestureDetector(
       onTap: () {
         if (itemId.isNotEmpty) {
@@ -348,81 +415,148 @@ class _HistoryCard extends StatelessWidget {
                 ]
               : null,
         ),
-        padding: const EdgeInsets.all(14),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // 썸네일
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(8),
-                  child: Container(
-                    width: 64,
-                    height: 64,
-                    color: BackgroundColor,
-                    child: thumbnailUrl != null && thumbnailUrl!.isNotEmpty
-                        ? Image.network(
-                            thumbnailUrl!,
-                            fit: BoxFit.cover,
-                            errorBuilder: (_, __, ___) =>
-                                const Icon(Icons.image_outlined, color: BorderColor),
-                          )
-                        : const Icon(Icons.image_outlined, color: BorderColor),
+        child: IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // 좌측 역할 인디케이터 스트립
+              Container(
+                width: 4,
+                decoration: BoxDecoration(
+                  color: roleColor,
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(defaultRadius),
+                    bottomLeft: Radius.circular(defaultRadius),
                   ),
                 ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Expanded(
-                            child: Text(
-                              title,
-                              style: const TextStyle(fontSize: 15),
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
-                            ),
+              ),
+              // 메인 컨텐츠
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.all(14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // 썸네일
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(8),
+                          child: Container(
+                            width: 64,
+                            height: 64,
+                            color: BackgroundColor,
+                            child: thumbnailUrl != null && thumbnailUrl!.isNotEmpty
+                                ? Builder(
+                                    builder: (context) {
+                                      final bool isVideo = isVideoFile(thumbnailUrl!);
+                                      final String displayUrl = isVideo
+                                          ? getVideoThumbnailUrl(thumbnailUrl!)
+                                          : thumbnailUrl!;
+                                      
+                                      return CachedNetworkImage(
+                                        imageUrl: displayUrl,
+                                        cacheManager: ItemImageCacheManager.instance,
+                                        fit: BoxFit.cover,
+                                        placeholder: (context, url) => Container(
+                                          color: BackgroundColor,
+                                          child: const Center(
+                                            child: CircularProgressIndicator(
+                                              strokeWidth: 2,
+                                            ),
+                                          ),
+                                        ),
+                                        errorWidget: (context, url, error) => Container(
+                                          color: BackgroundColor,
+                                          child: const Icon(
+                                            Icons.image_outlined,
+                                            color: BorderColor,
+                                          ),
+                                        ),
+                                      );
+                                    },
+                                  )
+                                : const Icon(Icons.image_outlined, color: BorderColor),
                           ),
-                          const SizedBox(width: 8),
-                          Container(
-                            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-                            decoration: BoxDecoration(
-                              color: getTradeStatusColor(status).withValues(alpha: 0.1),
-                              borderRadius: defaultBorder,
-                            ),
-                            child: Text(
-                              status,
-                              style: TextStyle(
-                                color: getTradeStatusColor(status),
-                                fontSize: 12,
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              // 역할 태그와 제목
+                              Row(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  // 역할 태그
+                                  Container(
+                                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                                    decoration: BoxDecoration(
+                                      color: roleSubColor,
+                                      borderRadius: BorderRadius.circular(4),
+                                    ),
+                                    child: Text(
+                                      roleLabel,
+                                      style: TextStyle(
+                                        color: roleTextColor,
+                                        fontSize: 11,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 6),
+                                  Expanded(
+                                    child: Text(
+                                      title,
+                                      style: const TextStyle(fontSize: 15),
+                                      maxLines: 2,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                ],
                               ),
-                            ),
+                              const SizedBox(height: 8),
+                              // 상태 배지와 가격
+                              Row(
+                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                crossAxisAlignment: CrossAxisAlignment.center,
+                                children: [
+                                  Container(
+                                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                                    decoration: BoxDecoration(
+                                      color: getTradeStatusColor(status).withValues(alpha: 0.1),
+                                      borderRadius: defaultBorder,
+                                    ),
+                                    child: Text(
+                                      status,
+                                      style: TextStyle(
+                                        color: getTradeStatusColor(status),
+                                        fontSize: 12,
+                                      ),
+                                    ),
+                                  ),
+                                  Text(
+                                    _formatMoney(price),
+                                    style: const TextStyle(
+                                      fontSize: 13,
+                                      color: textColor,
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
                           ),
-                        ],
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        _formatMoney(price),
-                        style: const TextStyle(fontSize: 13, color: textColor),
-                      ),
-                      if (date != null) ...[
-                        const SizedBox(height: 4),
-                        Text(
-                          date!,
-                          style: const TextStyle(fontSize: 12, color: BorderColor),
                         ),
                       ],
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
           ],
+          ),
         ),
       ),
     );

--- a/lib/features/item/current_trade/screen/filtered_trade_list_screen.dart
+++ b/lib/features/item/current_trade/screen/filtered_trade_list_screen.dart
@@ -1,10 +1,14 @@
+import 'package:bidbird/core/managers/item_image_cache_manager.dart';
+import 'package:bidbird/core/utils/item/item_media_utils.dart';
 import 'package:bidbird/core/utils/item/item_trade_status_utils.dart';
 import 'package:bidbird/core/utils/ui_set/border_radius_style.dart';
 import 'package:bidbird/core/utils/ui_set/colors_style.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
+import '../data/repository/current_trade_repository.dart';
 import '../model/current_trade_entity.dart';
 import '../viewmodel/current_trade_viewmodel.dart';
 
@@ -12,47 +16,242 @@ class FilteredTradeListScreen extends StatelessWidget {
   const FilteredTradeListScreen({
     super.key,
     required this.actionType,
-    required this.isSeller,
+    this.isSeller,
+    this.actionTypes, // 여러 액션 타입을 받을 수 있도록 추가
   });
 
   final TradeActionType actionType;
-  final bool isSeller;
+  final bool? isSeller;
+  final List<TradeActionType>? actionTypes; // 여러 액션 타입 지원
 
   @override
   Widget build(BuildContext context) {
-    final viewModel = context.watch<CurrentTradeViewModel>();
+    // 기존 ViewModel이 있으면 재사용, 없으면 새로 생성
+    return _buildWithViewModel(context);
+  }
+
+  Widget _buildWithViewModel(BuildContext context) {
+    // 기존 Provider에서 ViewModel 찾기
+    CurrentTradeViewModel? existingViewModel;
+    try {
+      existingViewModel = Provider.of<CurrentTradeViewModel>(context, listen: false);
+    } catch (e) {
+      // Provider가 없으면 null
+    }
+
+    // 기존 ViewModel이 있으면 재사용
+    if (existingViewModel != null) {
+      return Consumer<CurrentTradeViewModel>(
+        builder: (context, viewModel, _) {
+          return _buildContent(context, viewModel);
+        },
+      );
+    }
+
+    // 새 ViewModel 생성 (기존 Provider가 없는 경우)
+    return ChangeNotifierProvider<CurrentTradeViewModel>(
+      create: (_) => CurrentTradeViewModel(
+        repository: CurrentTradeRepositoryImpl(),
+      )..loadData(),
+      child: Consumer<CurrentTradeViewModel>(
+        builder: (context, viewModel, _) {
+          return _buildContent(context, viewModel);
+        },
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, CurrentTradeViewModel viewModel) {
+    // 여러 액션 타입이 제공되면 그것을 사용, 아니면 단일 actionType 사용
+    final targetActionTypes = actionTypes ?? [actionType];
     
     // 액션 타입에 맞는 항목 필터링
-    final filteredItems = isSeller
-        ? viewModel.saleHistory
-            .where((item) => item.actionType == actionType)
-            .toList()
-        : viewModel.bidHistory
-            .where((item) => item.actionType == actionType)
-            .toList();
+    final List<dynamic> filteredItems;
+    
+    // 필터링 헬퍼 함수
+    bool shouldIncludeSaleItem(SaleHistoryItem item) {
+      // actionType이 none이 아니고 targetActionTypes에 포함되면 포함
+      if (item.actionType != TradeActionType.none && 
+          targetActionTypes.contains(item.actionType)) {
+        return true;
+      }
+      // actionType이 none이면 tradeStatusCode로 직접 판단
+      if (item.actionType == TradeActionType.none) {
+        if (item.tradeStatusCode == 510 && 
+            targetActionTypes.contains(TradeActionType.paymentRequired)) {
+          return true;
+        }
+        if (item.tradeStatusCode == 520 && !item.hasShippingInfo &&
+            targetActionTypes.contains(TradeActionType.shippingInfoRequired)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    
+    bool shouldIncludeBidItem(BidHistoryItem item) {
+      // actionType이 none이 아니고 targetActionTypes에 포함되면 포함
+      if (item.actionType != TradeActionType.none && 
+          targetActionTypes.contains(item.actionType)) {
+        return true;
+      }
+      // actionType이 none이면 tradeStatusCode로 직접 판단
+      if (item.actionType == TradeActionType.none) {
+        if (item.tradeStatusCode == 510 && 
+            targetActionTypes.contains(TradeActionType.paymentRequired)) {
+          return true;
+        }
+        if (item.tradeStatusCode == 520 && item.hasShippingInfo &&
+            targetActionTypes.contains(TradeActionType.purchaseConfirmRequired)) {
+          return true;
+        }
+      }
+      // auction_status_code=321이고 tradeStatusCode가 없으면 결제 대기
+      if ((item.tradeStatusCode == null || item.tradeStatusCode == 0) &&
+          item.auctionStatusCode == 321 &&
+          targetActionTypes.contains(TradeActionType.paymentRequired)) {
+        return true;
+      }
+      return false;
+    }
+    
+    // 액션 타입별로 아이템 그룹화
+    final Map<TradeActionType, List<dynamic>> itemsByActionType = {};
+    
+    // 각 액션 타입별로 아이템 수집
+    for (final actionType in targetActionTypes) {
+      itemsByActionType[actionType] = [];
+    }
+    
+    // 판매 아이템 분류
+    final saleItems = isSeller == null || isSeller == true
+        ? viewModel.saleHistory.where(shouldIncludeSaleItem).toList()
+        : <SaleHistoryItem>[];
+    
+    for (final item in saleItems) {
+      TradeActionType? itemActionType;
+      if (item.actionType != TradeActionType.none) {
+        itemActionType = item.actionType;
+      } else {
+        if (item.tradeStatusCode == 510) {
+          itemActionType = TradeActionType.paymentRequired;
+        } else if (item.tradeStatusCode == 520 && !item.hasShippingInfo) {
+          itemActionType = TradeActionType.shippingInfoRequired;
+        }
+      }
+      if (itemActionType != null && itemsByActionType.containsKey(itemActionType)) {
+        itemsByActionType[itemActionType]!.add(item);
+      }
+    }
+    
+    // 입찰 아이템 분류
+    final bidItems = isSeller == null || isSeller == false
+        ? viewModel.bidHistory.where(shouldIncludeBidItem).toList()
+        : <BidHistoryItem>[];
+    
+    for (final item in bidItems) {
+      TradeActionType? itemActionType;
+      if (item.actionType != TradeActionType.none) {
+        itemActionType = item.actionType;
+      } else {
+        if (item.tradeStatusCode == 510) {
+          itemActionType = TradeActionType.paymentRequired;
+        } else if (item.tradeStatusCode == 520 && item.hasShippingInfo) {
+          itemActionType = TradeActionType.purchaseConfirmRequired;
+        } else if ((item.tradeStatusCode == null || item.tradeStatusCode == 0) &&
+                   item.auctionStatusCode == 321) {
+          itemActionType = TradeActionType.paymentRequired;
+        }
+      }
+      if (itemActionType != null && itemsByActionType.containsKey(itemActionType)) {
+        itemsByActionType[itemActionType]!.add(item);
+      }
+    }
 
     // 액션 타입에 맞는 제목 가져오기
-    final title = _getTitle(actionType);
+    final title = actionTypes != null && actionTypes!.length > 1
+        ? '처리해야 할 거래'
+        : _getTitle(actionType);
+
+    // 전체 아이템 개수 확인
+    final totalItems = itemsByActionType.values.fold<int>(0, (sum, items) => sum + items.length);
 
     return Scaffold(
       appBar: AppBar(
         title: Text(title),
       ),
       body: SafeArea(
-        child: filteredItems.isEmpty
-            ? RefreshIndicator(
-                onRefresh: () => context.read<CurrentTradeViewModel>().refresh(),
-                child: const Center(child: Text('해당 내역이 없습니다.')),
-              )
-            : RefreshIndicator(
-                onRefresh: () => context.read<CurrentTradeViewModel>().refresh(),
-                child: ListView(
+        child: viewModel.isLoading
+            ? const Center(child: CircularProgressIndicator())
+            : totalItems == 0
+                ? RefreshIndicator(
+                    onRefresh: () => context.read<CurrentTradeViewModel>().refresh(),
+                    child: const Center(child: Text('해당 내역이 없습니다.')),
+                  )
+                : RefreshIndicator(
+                    onRefresh: () => context.read<CurrentTradeViewModel>().refresh(),
+                    child: ListView(
                   padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
                   children: [
-                    ...filteredItems.map((item) => Padding(
-                          padding: const EdgeInsets.only(bottom: 12),
-                          child: _buildHistoryCard(context, item, isSeller),
-                        )),
+                    // 액션 타입별로 섹션 생성
+                    ...targetActionTypes.where((actionType) {
+                      return itemsByActionType[actionType]?.isNotEmpty ?? false;
+                    }).expand((actionType) {
+                      final items = itemsByActionType[actionType]!;
+                      final sectionLabel = _getSectionLabel(actionType);
+                      
+                      // 섹션 내 아이템들의 역할 확인 (판매/구매)
+                      final saleCount = items.where((item) => item is SaleHistoryItem).length;
+                      final bidCount = items.where((item) => item is BidHistoryItem).length;
+                      
+                      // 섹션 색상 결정: 모두 판매면 초록색, 모두 구매면 파란색, 혼합이면 기본 파란색
+                      final Color sectionColor;
+                      if (saleCount > 0 && bidCount == 0) {
+                        // 모두 판매
+                        sectionColor = roleSalePrimary;
+                      } else if (bidCount > 0 && saleCount == 0) {
+                        // 모두 구매
+                        sectionColor = rolePurchasePrimary;
+                      } else {
+                        // 혼합 또는 기본
+                        sectionColor = blueColor;
+                      }
+                      
+                      return [
+                        // 섹션 헤더
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 8, top: 8),
+                          child: Row(
+                            children: [
+                              Container(
+                                width: 3,
+                                height: 16,
+                                decoration: BoxDecoration(
+                                  color: sectionColor,
+                                  borderRadius: BorderRadius.circular(2),
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Text(
+                                sectionLabel,
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        // 섹션 아이템들
+                        ...items.map((item) {
+                          final itemIsSeller = item is SaleHistoryItem;
+                          return Padding(
+                            padding: const EdgeInsets.only(bottom: 12),
+                            child: _buildHistoryCard(context, item, itemIsSeller),
+                          );
+                        }),
+                      ];
+                    }),
                   ],
                 ),
               ),
@@ -73,7 +272,26 @@ class FilteredTradeListScreen extends StatelessWidget {
     }
   }
 
+  String _getSectionLabel(TradeActionType actionType) {
+    switch (actionType) {
+      case TradeActionType.paymentRequired:
+        return '결제 대기';
+      case TradeActionType.shippingInfoRequired:
+        return '배송지 입력';
+      case TradeActionType.purchaseConfirmRequired:
+        return '구매 확정';
+      case TradeActionType.none:
+        return '';
+    }
+  }
+
   Widget _buildHistoryCard(BuildContext context, dynamic item, bool isSeller) {
+    // 역할 색상 결정
+    final roleColor = isSeller ? roleSalePrimary : rolePurchasePrimary;
+    final roleSubColor = isSeller ? roleSaleSub : rolePurchaseSub;
+    final roleTextColor = isSeller ? roleSaleText : rolePurchaseText;
+    final roleLabel = isSeller ? '판매' : '구매';
+
     if (isSeller) {
       final saleItem = item as SaleHistoryItem;
       return GestureDetector(
@@ -83,95 +301,159 @@ class FilteredTradeListScreen extends StatelessWidget {
           }
         },
         child: Container(
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: defaultBorder,
-          border: Border.all(
-            color: BorderColor.withValues(alpha: 0.25),
-            width: 1,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: defaultBorder,
+            border: Border.all(
+              color: BorderColor.withValues(alpha: 0.25),
+              width: 1,
+            ),
           ),
-        ),
-        padding: const EdgeInsets.all(14),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
+          child: IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                // 썸네일
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(8),
-                  child: Container(
-                    width: 64,
-                    height: 64,
-                    color: BackgroundColor,
-                    child: saleItem.thumbnailUrl != null &&
-                            saleItem.thumbnailUrl!.isNotEmpty
-                        ? Image.network(
-                            saleItem.thumbnailUrl!,
-                            fit: BoxFit.cover,
-                            errorBuilder: (_, __, ___) =>
-                                const Icon(Icons.image_outlined,
-                                    color: BorderColor),
-                          )
-                        : const Icon(Icons.image_outlined, color: BorderColor),
+                // 좌측 역할 인디케이터 스트립
+                Container(
+                  width: 4,
+                  decoration: BoxDecoration(
+                    color: roleColor,
+                    borderRadius: const BorderRadius.only(
+                      topLeft: Radius.circular(defaultRadius),
+                      bottomLeft: Radius.circular(defaultRadius),
+                    ),
                   ),
                 ),
-                const SizedBox(width: 12),
+                // 메인 컨텐츠
                 Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Expanded(
-                            child: Text(
-                              saleItem.title,
-                              style: const TextStyle(fontSize: 15),
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
+                  child: Padding(
+                    padding: const EdgeInsets.all(14),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            // 썸네일
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(8),
+                              child: Container(
+                                width: 64,
+                                height: 64,
+                                color: BackgroundColor,
+                                child: saleItem.thumbnailUrl != null &&
+                                        saleItem.thumbnailUrl!.isNotEmpty
+                                  ? Builder(
+                                      builder: (context) {
+                                        final bool isVideo = isVideoFile(saleItem.thumbnailUrl!);
+                                        final String displayUrl = isVideo
+                                            ? getVideoThumbnailUrl(saleItem.thumbnailUrl!)
+                                            : saleItem.thumbnailUrl!;
+                                        
+                                        return CachedNetworkImage(
+                                          imageUrl: displayUrl,
+                                          cacheManager: ItemImageCacheManager.instance,
+                                          fit: BoxFit.cover,
+                                          placeholder: (context, url) => Container(
+                                            color: BackgroundColor,
+                                            child: const Center(
+                                              child: CircularProgressIndicator(
+                                                strokeWidth: 2,
+                                              ),
+                                            ),
+                                          ),
+                                          errorWidget: (context, url, error) => Container(
+                                            color: BackgroundColor,
+                                            child: const Icon(
+                                              Icons.image_outlined,
+                                              color: BorderColor,
+                                            ),
+                                          ),
+                                        );
+                                      },
+                                    )
+                                  : const Icon(Icons.image_outlined, color: BorderColor),
                             ),
                           ),
-                          const SizedBox(width: 8),
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 10, vertical: 4),
-                            decoration: BoxDecoration(
-                              color: getTradeStatusColor(saleItem.status)
-                                  .withValues(alpha: 0.1),
-                              borderRadius: defaultBorder,
-                            ),
-                            child: Text(
-                              saleItem.status,
-                              style: TextStyle(
-                                color: getTradeStatusColor(saleItem.status),
-                                fontSize: 12,
-                              ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                // 역할 태그와 제목
+                                Row(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    // 역할 태그
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                                      decoration: BoxDecoration(
+                                        color: roleSubColor,
+                                        borderRadius: BorderRadius.circular(4),
+                                      ),
+                                      child: Text(
+                                        roleLabel,
+                                        style: TextStyle(
+                                          color: roleTextColor,
+                                          fontSize: 11,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ),
+                                    const SizedBox(width: 6),
+                                    Expanded(
+                                      child: Text(
+                                        saleItem.title,
+                                        style: const TextStyle(fontSize: 15),
+                                        maxLines: 2,
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                const SizedBox(height: 8),
+                                // 상태 배지와 가격
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                  children: [
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                                      decoration: BoxDecoration(
+                                        color: getTradeStatusColor(saleItem.status)
+                                            .withValues(alpha: 0.1),
+                                        borderRadius: defaultBorder,
+                                      ),
+                                      child: Text(
+                                        saleItem.status,
+                                        style: TextStyle(
+                                          color: getTradeStatusColor(saleItem.status),
+                                          fontSize: 12,
+                                        ),
+                                      ),
+                                    ),
+                                    Text(
+                                      _formatMoney(saleItem.price),
+                                      style: const TextStyle(
+                                        fontSize: 13,
+                                        color: textColor,
+                                        fontWeight: FontWeight.w500,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ],
                             ),
                           ),
                         ],
                       ),
-                      const SizedBox(height: 8),
-                      Text(
-                        '${_formatMoney(saleItem.price)}',
-                        style: const TextStyle(fontSize: 13, color: textColor),
-                      ),
-                      if (saleItem.date.isNotEmpty) ...[
-                        const SizedBox(height: 4),
-                        Text(
-                          saleItem.date,
-                          style:
-                              const TextStyle(fontSize: 12, color: BorderColor),
-                        ),
-                      ],
                     ],
                   ),
                 ),
-              ],
+              ),
+            ],
             ),
-          ],
-        ),
+          ),
         ),
       );
     } else {
@@ -191,79 +473,150 @@ class FilteredTradeListScreen extends StatelessWidget {
               width: 1,
             ),
           ),
-          padding: const EdgeInsets.all(14),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // 썸네일
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(8),
-                    child: Container(
-                      width: 64,
-                      height: 64,
-                      color: BackgroundColor,
-                      child: bidItem.thumbnailUrl != null &&
-                              bidItem.thumbnailUrl!.isNotEmpty
-                          ? Image.network(
-                              bidItem.thumbnailUrl!,
-                              fit: BoxFit.cover,
-                              errorBuilder: (_, __, ___) =>
-                                  const Icon(Icons.image_outlined,
-                                      color: BorderColor),
-                            )
-                          : const Icon(Icons.image_outlined, color: BorderColor),
+          child: IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // 좌측 역할 인디케이터 스트립
+                Container(
+                  width: 4,
+                  decoration: BoxDecoration(
+                    color: roleColor,
+                    borderRadius: const BorderRadius.only(
+                      topLeft: Radius.circular(defaultRadius),
+                      bottomLeft: Radius.circular(defaultRadius),
                     ),
                   ),
-                  const SizedBox(width: 12),
-                  Expanded(
+                ),
+                // 메인 컨텐츠
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(14),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Row(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Expanded(
-                              child: Text(
-                                bidItem.title,
-                                style: const TextStyle(fontSize: 15),
-                                maxLines: 2,
-                                overflow: TextOverflow.ellipsis,
-                              ),
+                            // 썸네일
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(8),
+                              child: Container(
+                                width: 64,
+                                height: 64,
+                                color: BackgroundColor,
+                                child: bidItem.thumbnailUrl != null &&
+                                        bidItem.thumbnailUrl!.isNotEmpty
+                                  ? Builder(
+                                      builder: (context) {
+                                        final bool isVideo = isVideoFile(bidItem.thumbnailUrl!);
+                                        final String displayUrl = isVideo
+                                            ? getVideoThumbnailUrl(bidItem.thumbnailUrl!)
+                                            : bidItem.thumbnailUrl!;
+                                        
+                                        return CachedNetworkImage(
+                                          imageUrl: displayUrl,
+                                          cacheManager: ItemImageCacheManager.instance,
+                                          fit: BoxFit.cover,
+                                          placeholder: (context, url) => Container(
+                                            color: BackgroundColor,
+                                            child: const Center(
+                                              child: CircularProgressIndicator(
+                                                strokeWidth: 2,
+                                              ),
+                                            ),
+                                          ),
+                                          errorWidget: (context, url, error) => Container(
+                                            color: BackgroundColor,
+                                            child: const Icon(
+                                              Icons.image_outlined,
+                                              color: BorderColor,
+                                            ),
+                                          ),
+                                        );
+                                      },
+                                    )
+                                  : const Icon(Icons.image_outlined, color: BorderColor),
                             ),
-                            const SizedBox(width: 8),
-                            Container(
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 10, vertical: 4),
-                              decoration: BoxDecoration(
-                                color: getTradeStatusColor(bidItem.status)
-                                    .withValues(alpha: 0.1),
-                                borderRadius: defaultBorder,
-                              ),
-                              child: Text(
-                                bidItem.status,
-                                style: TextStyle(
-                                  color: getTradeStatusColor(bidItem.status),
-                                  fontSize: 12,
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                // 역할 태그와 제목
+                                Row(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    // 역할 태그
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                                      decoration: BoxDecoration(
+                                        color: roleSubColor,
+                                        borderRadius: BorderRadius.circular(4),
+                                      ),
+                                      child: Text(
+                                        roleLabel,
+                                        style: TextStyle(
+                                          color: roleTextColor,
+                                          fontSize: 11,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ),
+                                    const SizedBox(width: 6),
+                                    Expanded(
+                                      child: Text(
+                                        bidItem.title,
+                                        style: const TextStyle(fontSize: 15),
+                                        maxLines: 2,
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                    ),
+                                  ],
                                 ),
-                              ),
+                                const SizedBox(height: 8),
+                                // 상태 배지와 가격
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                  children: [
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                                      decoration: BoxDecoration(
+                                        color: getTradeStatusColor(bidItem.status)
+                                            .withValues(alpha: 0.1),
+                                        borderRadius: defaultBorder,
+                                      ),
+                                      child: Text(
+                                        bidItem.status,
+                                        style: TextStyle(
+                                          color: getTradeStatusColor(bidItem.status),
+                                          fontSize: 12,
+                                        ),
+                                      ),
+                                    ),
+                                    Text(
+                                      _formatMoney(bidItem.price),
+                                      style: const TextStyle(
+                                        fontSize: 13,
+                                        color: textColor,
+                                        fontWeight: FontWeight.w500,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ],
                             ),
-                          ],
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          '${_formatMoney(bidItem.price)}',
-                          style:
-                              const TextStyle(fontSize: 13, color: textColor),
-                        ),
-                      ],
-                    ),
+                          ),
+                        ],
+                      ),
+                    ],
                   ),
-                ],
+                ),
               ),
             ],
+            ),
           ),
         ),
       );

--- a/lib/features/item/current_trade/viewmodel/current_trade_viewmodel.dart
+++ b/lib/features/item/current_trade/viewmodel/current_trade_viewmodel.dart
@@ -96,8 +96,14 @@ class CurrentTradeViewModel extends ChangeNotifier {
       _setLoading(true);
       _error = null;
 
-      _bidHistory = await _repository.fetchMyBidHistory();
-      _saleHistory = await _repository.fetchMySaleHistory();
+      // 병렬로 입찰/판매 내역 조회
+      final results = await Future.wait([
+        _repository.fetchMyBidHistory(),
+        _repository.fetchMySaleHistory(),
+      ]);
+
+      _bidHistory = results[0] as List<BidHistoryItem>;
+      _saleHistory = results[1] as List<SaleHistoryItem>;
 
       notifyListeners();
     } catch (e) {


### PR DESCRIPTION
PR 요약
본 PR은 현재 거래내역 화면을 사용자의 즉각적인 업무 중심으로 재구성하는 것을 목적으로 합니다. 불필요한 정보 노출을 제거하고, 진행 중인 거래와 즉시 처리해야 할 업무만 명확하게 확인할 수 있도록 UI를 개선했습니다.

변경 사항
1. 현재 거래내역 범위 명확화 • 현재 거래내역 화면에 완료·종료된 거래를 제외 • 진행 중인 거래만 표시하도록 수정 • 전체 거래내역은 하단에 이동 버튼 추가

2. 즉각적인 업무 인지 중심 UI 개선 • 사용자가 바로 수행해야 할 액션을 최상단에 노출 • 프로세스 단계와 현재 진행 상태를 한눈에 파악 가능하도록 구조 개선 • 불필요한 설명 및 중복 정보 제거

3. 판매내역·입찰내역 통합 • 판매내역과 입찰내역을 단일 목록으로 통합 • 사용자가 즉시 처리해야 할 업무 항목만 필터링하여 표시

기대 효과
	•  현재 진행 중인 단계에 대한 인지 속도 향상
	•  사용자 혼란 감소 및 거래시간 단축
	•  거래 프로세스 이해도 개선