### PR TITLE
Redesign/ 홈화면 디자인 수정

### DIFF
--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -27,26 +27,31 @@ class _HomeScreenState extends State<HomeScreen> {
           return Scaffold(
             appBar: const HomeAppBar(),
             body: SafeArea(
-              child: Stack(
-                children: [
-                  TransparentRefreshIndicator(
-                    onRefresh: context.read<HomeViewmodel>().handleRefresh,
-                    child: CustomScrollView(
-                      keyboardDismissBehavior:
-                          ScrollViewKeyboardDismissBehavior.onDrag,
-                      controller: viewModel.scrollController,
-                      physics: const AlwaysScrollableScrollPhysics(),
-                      slivers: [
-                        // 키워드 영역
-                        const KeywordWidget(),
-
-                        // 슬라이버 그리드 search 모드가 필요 없어짐 viewmodel에서 그냥 데이터만 뿌려주면 되기 때문
-                        const ItemGrid(),
-                      ],
-                    ),
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 1200),
+                  child: Stack(
+                    children: [
+                      TransparentRefreshIndicator(
+                        onRefresh: context.read<HomeViewmodel>().handleRefresh,
+                        child: CustomScrollView(
+                          keyboardDismissBehavior:
+                              ScrollViewKeyboardDismissBehavior.onDrag,
+                          controller: viewModel.scrollController,
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          slivers: [
+                            // 키워드 영역
+                            const KeywordWidget(),
+    
+                            // 슬라이버 그리드 search 모드가 필요 없어짐 viewmodel에서 그냥 데이터만 뿌려주면 되기 때문
+                            const ItemGrid(),
+                          ],
+                        ),
+                      ),
+                      child!, // 불변 위젯을 child로 분리
+                    ],
                   ),
-                  child!, // 불변 위젯을 child로 분리
-                ],
+                ),
               ),
             ),
           );

--- a/lib/features/home/presentation/widgets/Item_grid.dart
+++ b/lib/features/home/presentation/widgets/Item_grid.dart
@@ -16,10 +16,18 @@ class ItemGrid extends StatelessWidget {
           final items = viewModel.items;
           final itemsLength = items.length;
 
+          final double width = MediaQuery.of(context).size.width;
+          int crossAxisCount = 2;
+          if (width >= 900) {
+            crossAxisCount = 4;
+          } else if (width >= 600) {
+            crossAxisCount = 3;
+          }
+
           return SliverGrid(
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 2,
-              childAspectRatio: 0.85,
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: crossAxisCount,
+              childAspectRatio: 0.75,
               mainAxisSpacing: 10,
               crossAxisSpacing: 10,
             ),

--- a/lib/features/home/presentation/widgets/floating_menu.dart
+++ b/lib/features/home/presentation/widgets/floating_menu.dart
@@ -88,6 +88,7 @@ class _FloatingMenuState extends State<FloatingMenu> {
           bottom: 16,
           right: 16,
           child: FloatingActionButton(
+            shape: const CircleBorder(),
             backgroundColor: blueColor,
             onPressed: () => setState(() => _open = !_open),
             child: Icon(_open ? Icons.close : Icons.add, color: Colors.white),

--- a/lib/features/home/presentation/widgets/home_timer_section.dart
+++ b/lib/features/home/presentation/widgets/home_timer_section.dart
@@ -15,9 +15,9 @@ class HomeTimerSection extends StatelessWidget {
     final isFinished = now.isAfter(finishTime);
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
       decoration: BoxDecoration(
-        color: isFinished ? Colors.black45 : const Color(0xffef6b6b),
+        color: Colors.black54,
         borderRadius: BorderRadius.circular(4),
       ),
       child: Text(

--- a/lib/features/home/presentation/widgets/item_card.dart
+++ b/lib/features/home/presentation/widgets/item_card.dart
@@ -19,7 +19,6 @@ class ItemCard extends StatelessWidget {
     return RepaintBoundary(
       child: GestureDetector(
         onTap: () {
-          // item_detail 페이지로 이동
           context.push('/item/${item.item_id}');
         },
         child: Column(
@@ -30,134 +29,117 @@ class ItemCard extends StatelessWidget {
                 borderRadius: BorderRadius.circular(8.7),
                 boxShadow: [defaultShadow],
               ),
-              child: Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Column(
-                  children: [
-                    Stack(
-                      children: [
-                        FixedRatioThumbnail(
-                          imageUrl: item.thumbnail_image,
-                          aspectRatio: 1.0,
-                          borderRadius: BorderRadius.circular(defaultRadius),
-                        ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Stack(
+                    children: [
+                      FixedRatioThumbnail(
+                        imageUrl: item.thumbnail_image,
+                        aspectRatio: 1.0,
+                        borderRadius: BorderRadius.circular(defaultRadius),
+                      ),
 
-                        // 잔여 시간 (상세 화면과 동일 스타일)
-                        Positioned(
-                          top: 8,
-                          left: 8,
-                          child: HomeTimerSection(finishTime: item.finishTime),
-                        ),
+                      Positioned(
+                        top: 8,
+                        right: 8,
+                        child: HomeTimerSection(finishTime: item.finishTime),
+                      ),
 
-                        // 입찰 건수
-                        Positioned(
-                          bottom: 6,
-                          left: 6,
-                          right: 8,
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Container(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 8,
-                                  vertical: 4,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: Colors.black45,
-                                  borderRadius: BorderRadius.circular(15),
-                                ),
-                                child: Row(
-                                  spacing: 3,
-                                  children: [
-                                    const Icon(
-                                      Icons.account_circle,
-                                      color: Colors.white,
-                                      size: 12,
-                                    ),
-                                    Text(
-                                      "${item.auctions.bid_count}",
-                                      style: TextStyle(
-                                        color: Colors.white,
-                                        fontSize: 12,
-                                        fontWeight: FontWeight.w600,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ],
+                      Positioned(
+                        bottom: 0,
+                        left: 0,
+                        right: 0,
+                        child: Container(
+                          height: 48,
+                          decoration: BoxDecoration(
+                            borderRadius: const BorderRadius.only(
+                              bottomLeft: Radius.circular(defaultRadius),
+                              bottomRight: Radius.circular(defaultRadius),
+                            ),
+                            gradient: const LinearGradient(
+                              colors: [Colors.transparent, Colors.black87],
+                              begin: Alignment.topCenter,
+                              end: Alignment.bottomCenter,
+                            ),
                           ),
                         ),
+                      ),
 
-                        //현재 가격
-                        Positioned(
-                          bottom: 6,
-                          right: 6,
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Container(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 8,
-                                  vertical: 4,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: Colors.black45,
-                                  borderRadius: BorderRadius.circular(15),
-                                ),
-                                child: Text(
-                                  "${item.auctions.current_price.toCommaString()}원",
-                                  style: TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 12,
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                              ),
-                            ],
+                      Positioned(
+                        bottom: 12,
+                        left: 12,
+                        child: Text(
+                          "${item.auctions.current_price.toCommaString()}원",
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
                           ),
                         ),
-                        // 시간 만료 되면 나오는 UI
-                        if (DateTime.now().isAfter(item.finishTime))
-                          Positioned.fill(
-                            child: Container(
-                              decoration: BoxDecoration(
-                                color: Colors.black54,
-                                borderRadius: defaultBorder,
+                      ),
+
+                      Positioned(
+                        bottom: 12,
+                        right: 12,
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            const Icon(
+                              Icons.person,
+                              color: Colors.white,
+                              size: 15,
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              "${item.auctions.bid_count}",
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 13,
+                                fontWeight: FontWeight.w500,
                               ),
-                              child: Align(
-                                alignment: Alignment.center,
-                                child: Text(
-                                  "종료된 상품입니다",
-                                  style: TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 15,
-                                    fontWeight: FontWeight.w600,
-                                  ),
+                            ),
+                          ],
+                        ),
+                      ),
+
+                      if (DateTime.now().isAfter(item.finishTime))
+                        Positioned.fill(
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: Colors.black54,
+                              borderRadius:
+                              BorderRadius.circular(defaultRadius),
+                            ),
+                            child: const Center(
+                              child: Text(
+                                "종료된 상품입니다",
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
                                 ),
                               ),
                             ),
                           ),
-                      ],
-                    ),
-
-                    // const SizedBox(height: 8),
-                    Align(
-                      alignment: Alignment.topLeft,
-                      child: Padding(
-                        padding: const EdgeInsets.only(top: 4),
-                        child: Text(
-                          title,
-                          maxLines: 1,
-                          style: const TextStyle(
-                            fontWeight: FontWeight.w500,
-                            overflow: TextOverflow.ellipsis,
-                          ),
                         ),
+                    ],
+                  ),
+
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
+                    child: Text(
+                      title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.bold,
                       ),
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
             ),
           ],


### PR DESCRIPTION
1. 디자인 수정
   - 매물 카드 섹션 공백 제거
   - 플로팅 버튼 원형 변경
   - 가격 및 입찰 자 수 위치 변경
   - 카운트 색상 변경
2. 홈화면 반응형 크기 적용
3. rpc 함수 수정
   - agreed_at 기준으로 정렬
4. 반응형 레이아웃 적용 기기별 가변 그리드: 모바일에서는 2열, 태블릿에서는 3열, 데스크탑/넓은 화면에서는 4열로 아이템 카드가 자동으로 재배치되도록 수정