### PR TITLE
FIX/ 뒤로가기가 안되는 현상을 해결했습니다

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -189,14 +189,29 @@ GoRouter createAppRouter(BuildContext context) {
             routes: [
               GoRoute(
                 path: '/home',
-                pageBuilder: (context, state) => buildPage(
-                  context: context,
-                  state: state,
-                  child: const RootTabBackHandler(
-                    isHome: true,
-                    child: HomeScreen(),
-                  ),
-                ),
+                pageBuilder: (context, state) {
+                  final authVM = context.read<AuthViewModel>();
+
+                  // 닉네임이 없으면 아예 HomeScreen을 빌드하지 않고 빈 화면 혹은 스플래시를 반환
+                  if (authVM.user?.nick_name == null) {
+                    return buildPage(
+                      context: context,
+                      state: state,
+                      child: const Scaffold(
+                        body: Center(child: CircularProgressIndicator()),
+                      ),
+                    );
+                  }
+
+                  return buildPage(
+                    context: context,
+                    state: state,
+                    child: const RootTabBackHandler(
+                      isHome: true,
+                      child: HomeScreen(),
+                    ),
+                  );
+                },
                 routes: [
                   GoRoute(
                     path: 'search',

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,3 +1,4 @@
+import 'package:bidbird/core/router/root_tab_back_handler.dart';
 import 'package:bidbird/core/widgets/bottom_nav_bar.dart';
 import 'package:bidbird/core/widgets/item/components/others/double_back_exit_handler.dart';
 import 'package:bidbird/features/auth/presentation/screens/auth_set_profile_screen.dart';
@@ -59,6 +60,12 @@ import 'package:provider/provider.dart';
 final RouteObserver<ModalRoute<void>> routeObserver =
     RouteObserver<ModalRoute<void>>();
 final GlobalKey<NavigatorState> rootNavigatorKey = GlobalKey<NavigatorState>();
+final doubleBackHandler = DoubleBackExitHandler();
+
+final homeNavKey = GlobalKey<NavigatorState>();
+final bidNavKey = GlobalKey<NavigatorState>();
+final chatNavKey = GlobalKey<NavigatorState>();
+final mypageNavKey = GlobalKey<NavigatorState>();
 
 /// [수정 핵심] 플랫폼에 따라 iOS는 CupertinoPage(스와이프 가능), 나머지는 애니메이션 없는 페이지 반환
 Page<T> buildPage<T>({
@@ -75,7 +82,6 @@ Page<T> buildPage<T>({
 
 GoRouter createAppRouter(BuildContext context) {
   final AuthViewModel authVM = context.read<AuthViewModel>();
-  final doubleBackHandler = DoubleBackExitHandler();
 
   return GoRouter(
     observers: [routeObserver],
@@ -145,34 +151,51 @@ GoRouter createAppRouter(BuildContext context) {
 
       // --- 메인 쉘 (바텀 네비게이션 포함) ---
       StatefulShellRoute.indexedStack(
+        // StatefulShellRoute의 builder 부분 수정
         builder: (context, state, navigationShell) {
           return PopScope(
             canPop: false,
-            onPopInvokedWithResult: (didPop, result) async {
+            onPopInvokedWithResult: (didPop, result) {
               if (didPop) return;
-              final location = state.uri.toString();
-              if (location != '/home') {
-                context.go('/home');
+
+              final NavigatorState? currentTabNav = _getCurrentNavigator(
+                navigationShell.currentIndex,
+              );
+
+              // 하위 스택이 있으면 pop
+              if (currentTabNav != null && currentTabNav.canPop()) {
+                currentTabNav.pop();
               } else {
-                doubleBackHandler.onWillPop(context);
+                // 루트 탭이면 홈으로 가거나 종료 핸들러 실행
+                if (navigationShell.currentIndex != 0) {
+                  navigationShell.goBranch(0);
+                } else {
+                  doubleBackHandler.onWillPop(context);
+                }
               }
             },
             child: Scaffold(
               body: navigationShell,
-              bottomNavigationBar: BottomNavBar(navigationShell: navigationShell),
+              bottomNavigationBar: BottomNavBar(
+                navigationShell: navigationShell,
+              ),
             ),
           );
         },
         branches: [
           // 1. 홈 탭
           StatefulShellBranch(
+            navigatorKey: homeNavKey,
             routes: [
               GoRoute(
                 path: '/home',
                 pageBuilder: (context, state) => buildPage(
                   context: context,
                   state: state,
-                  child: const HomeScreen(),
+                  child: const RootTabBackHandler(
+                    isHome: true,
+                    child: HomeScreen(),
+                  ),
                 ),
                 routes: [
                   GoRoute(
@@ -189,13 +212,17 @@ GoRouter createAppRouter(BuildContext context) {
           ),
           // 2. 거래 탭
           StatefulShellBranch(
+            navigatorKey: bidNavKey,
             routes: [
               GoRoute(
                 path: '/bid',
                 pageBuilder: (context, state) => buildPage(
                   context: context,
                   state: state,
-                  child: const CurrentTradeScreen(),
+                  child: const RootTabBackHandler(
+                    isHome: true,
+                    child: CurrentTradeScreen(),
+                  ),
                 ),
                 routes: [
                   GoRoute(
@@ -229,26 +256,34 @@ GoRouter createAppRouter(BuildContext context) {
           ),
           // 3. 채팅 탭
           StatefulShellBranch(
+            navigatorKey: chatNavKey,
             routes: [
               GoRoute(
                 path: '/chat',
                 pageBuilder: (context, state) => buildPage(
                   context: context,
                   state: state,
-                  child: const ChatScreen(),
+                  child: const RootTabBackHandler(
+                    isHome: true,
+                    child: ChatScreen(),
+                  ),
                 ),
               ),
             ],
           ),
           // 4. 마이페이지 탭
           StatefulShellBranch(
+            navigatorKey: mypageNavKey,
             routes: [
               GoRoute(
                 path: '/mypage',
                 pageBuilder: (context, state) => buildPage(
                   context: context,
                   state: state,
-                  child: const MypageScreen(),
+                  child: const RootTabBackHandler(
+                    isHome: true,
+                    child: MypageScreen(),
+                  ),
                 ),
                 routes: [
                   GoRoute(
@@ -536,3 +571,19 @@ Widget _noTransitionBuilder(
   Animation<double> sa,
   Widget child,
 ) => child;
+
+/// 현재 인덱스에 해당하는 탭의 NavigatorState를 반환하는 함수
+NavigatorState? _getCurrentNavigator(int index) {
+  switch (index) {
+    case 0:
+      return homeNavKey.currentState;
+    case 1:
+      return bidNavKey.currentState;
+    case 2:
+      return chatNavKey.currentState;
+    case 3:
+      return mypageNavKey.currentState;
+    default:
+      return null;
+  }
+}

--- a/lib/core/router/root_tab_back_handler.dart
+++ b/lib/core/router/root_tab_back_handler.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/cupertino.dart';
+import 'package:go_router/go_router.dart';
+
+import 'app_router.dart';
+
+class RootTabBackHandler extends StatelessWidget {
+  final Widget child;
+  final bool isHome;
+
+  const RootTabBackHandler({
+    super.key,
+    required this.child,
+    this.isHome = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false, // 시스템 팝 방지
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
+
+        // 1. 현재 탭 안에서 뒤로 갈 페이지가 있는지 확인
+        if (Navigator.of(context).canPop()) {
+          Navigator.of(context).pop();
+        } else {
+          // 2. 탭의 첫 페이지라면
+          if (!isHome) {
+            // 홈 탭이 아니면 홈으로 강제 이동
+            StatefulNavigationShell.of(context).goBranch(0);
+          } else {
+            // 홈 탭의 첫 페이지면 토스트 출력
+            doubleBackHandler.onWillPop(context);
+          }
+        }
+      },
+      child: child,
+    );
+  }
+}

--- a/lib/core/widgets/item/components/others/double_back_exit_handler.dart
+++ b/lib/core/widgets/item/components/others/double_back_exit_handler.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 
 class DoubleBackExitHandler {
   DateTime? _lastPressedAt;
 
-  bool onWillPop(BuildContext context) {
+  void onWillPop(BuildContext context) {
     final now = DateTime.now();
 
     if (_lastPressedAt == null ||
@@ -24,10 +25,8 @@ class DoubleBackExitHandler {
         textColor: Colors.white,
         fontSize: 14,
       );
-
-      return false; // 앱 종료 막음
+      return;
     }
-
-    return true; // 앱 종료 허용
+    SystemNavigator.pop();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -181,24 +181,25 @@ class _MyAppState extends State<MyApp> {
           });
         }
 
-        return GestureDetector(
-          onTap: () {
-            FocusManager.instance.primaryFocus?.unfocus();
-          },
-          behavior: HitTestBehavior.translucent,
-          child: MaterialApp.router(
-            title: widget.title,
-            debugShowCheckedModeBanner: false,
-            color: const Color(0xFFF5F5F5),
-            theme: theme,
-            builder: (context, child) {
-              return ColoredBox(
+        return MaterialApp.router(
+          title: widget.title,
+          debugShowCheckedModeBanner: false,
+          color: const Color(0xFFF5F5F5),
+          theme: theme,
+          // [수정] GestureDetector를 builder 내부로 이동
+          builder: (context, child) {
+            return GestureDetector(
+              onTap: () {
+                FocusManager.instance.primaryFocus?.unfocus();
+              },
+              behavior: HitTestBehavior.translucent,
+              child: ColoredBox(
                 color: const Color(0xFFF5F5F5),
                 child: child ?? const SizedBox.shrink(),
-              );
-            },
-            routerConfig: _router!,
-          ),
+              ),
+            );
+          },
+          routerConfig: _router!,
         );
       },
     );


### PR DESCRIPTION
앱 최초 진입 후 홈 화면을 제외한 현재 거래, 채팅, 마이페이지 탭에 딱 한 번 진입(rout 스택 쌓이지 않음)후에 뒤로가기 탭 시 앱이 double_back_exit_handler.dart 로직을 타지 않고 바로 종료되는 현상이 있었습니다 해결 했지만 지선생(제미나이 선생님)의 도움을 받아서 해결 한 것이기에 찝찝한 마음이 듭니다. 하지만 저의 능력으로는 절대 해결 못하는 문제였기 때문에 해결은 했습니다. 감사합니다(__)